### PR TITLE
fix: Set email_verified_at on user registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,15 @@
-## [1.0.0] - 2025-03-17
-- Initial release
+## [1.0.5] - 2026-01-10
+- Set email_verified_at on registration when verification is required
+- Set email_verified_at for users registered via OAuth providers
 
-## [1.0.1] - 2025-05-20
-- Fix wrong provider name in composer.json
-
-## [1.0.2] - 2025-07-31
-- Added config file
-- Minor bug fixes
+## [1.0.4] - 2025-10-15
+- Add support for firebase authentication
 
 ## [1.0.3] - 2025-10-01
 - Add response interception hooks
 - Implement pre-registration email and phone verification
 - Add response and middleware customization
 
-## [1.0.4] - 2025-10-15
-- Add support for firebase authentication
+## [1.0.2] - 2025-07-31
+- Added config file
+- Minor bug fixes

--- a/src/Http/Controllers/Auth/AuthController.php
+++ b/src/Http/Controllers/Auth/AuthController.php
@@ -74,6 +74,10 @@ class AuthController extends Controller
             $user_data = $request->only(['first_name', 'last_name', 'email', 'password', 'phone', 'username']);
             $user_data['password'] = Hash::make($request->password);
 
+            if ($requireEmailVerification) {
+                $user_data['email_verified_at'] = now();
+            }
+
             $User = config('user-authentication.user_model', User::class);
             $user = $User::create($user_data);
             UserRegisteredEvent::dispatch($user);
@@ -455,6 +459,7 @@ class AuthController extends Controller
                 'first_name' => $name,
                 'email' => $email,
                 'password' => Hash::make(Str::random(10)),
+                'email_verified_at' => now(),
             ];
             $existing_user = $User::create($user_data);
             UserRegisteredEvent::dispatch($existing_user);

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -24,6 +24,7 @@ class User extends Authenticatable
         'last_name',
         'username',
         'phone',
+        'email_verified_at',
     ];
 
     /**


### PR DESCRIPTION
When email verification is required and passes, or when users register via OAuth providers, set the email_verified_at timestamp on the user.