### PR TITLE
feat(oauth): Extend OauthAccount and support configurable scopes

### DIFF
--- a/config/user-authentication.php
+++ b/config/user-authentication.php
@@ -9,6 +9,13 @@ return [
 
     'response_formatter' => \Whilesmart\UserAuthentication\ResponseFormatters\DefaultResponseFormatter::class,
 
+    'oauth_scopes' => [
+        // 'github' => ['read:user', 'user:email'],
+        // 'google' => ['openid', 'profile', 'email'],
+    ],
+
+    'encrypt_oauth_tokens' => env('USER_AUTH_ENCRYPT_OAUTH_TOKENS', false),
+
     'middleware_hooks' => [
         // Add your middleware hook classes here
         // Example: \App\Http\Middleware\CustomAuthHook::class,

--- a/database/migrations/2026_02_11_000001_add_provider_fields_to_oauth_accounts_table.php
+++ b/database/migrations/2026_02_11_000001_add_provider_fields_to_oauth_accounts_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('oauth_accounts', function (Blueprint $table) {
+            $table->string('provider_id')->nullable()->after('provider');
+            $table->string('avatar_url')->nullable()->after('provider_id');
+            $table->text('token')->nullable()->after('avatar_url');
+
+            $table->unique(['provider', 'provider_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('oauth_accounts', function (Blueprint $table) {
+            $table->dropUnique(['provider', 'provider_id']);
+            $table->dropColumn(['provider_id', 'avatar_url', 'token']);
+        });
+    }
+};

--- a/src/Events/OauthUserAuthenticatedEvent.php
+++ b/src/Events/OauthUserAuthenticatedEvent.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Whilesmart\UserAuthentication\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Laravel\Socialite\Contracts\User as SocialiteUser;
+
+class OauthUserAuthenticatedEvent
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public Authenticatable $user;
+
+    public ?SocialiteUser $socialUser;
+
+    public string $driver;
+
+    public bool $isNewUser;
+
+    public function __construct(Authenticatable $user, ?SocialiteUser $socialUser, string $driver, bool $isNewUser = false)
+    {
+        $this->user = $user;
+        $this->socialUser = $socialUser;
+        $this->driver = $driver;
+        $this->isNewUser = $isNewUser;
+    }
+}

--- a/src/Http/Controllers/Auth/AuthController.php
+++ b/src/Http/Controllers/Auth/AuthController.php
@@ -15,6 +15,7 @@ use Kreait\Firebase\Exception\FirebaseException;
 use Kreait\Laravel\Firebase\Facades\Firebase;
 use Laravel\Socialite\Facades\Socialite;
 use Whilesmart\UserAuthentication\Enums\HookAction;
+use Whilesmart\UserAuthentication\Events\OauthUserAuthenticatedEvent;
 use Whilesmart\UserAuthentication\Events\UserLoggedInEvent;
 use Whilesmart\UserAuthentication\Events\UserLoggedOutEvent;
 use Whilesmart\UserAuthentication\Events\UserRegisteredEvent;
@@ -171,7 +172,14 @@ class AuthController extends Controller
     {
         $request = $this->runBeforeHooks($request, HookAction::OAUTH_LOGIN);
 
-        $url = Socialite::driver($driver)->stateless()->redirect()->getTargetUrl();
+        $socialite = Socialite::driver($driver)->stateless();
+
+        $scopes = config("user-authentication.oauth_scopes.{$driver}", []);
+        if (! empty($scopes)) {
+            $socialite->scopes($scopes);
+        }
+
+        $url = $socialite->redirect()->getTargetUrl();
 
         $response = $this->success([
             'url' => $url,
@@ -185,7 +193,23 @@ class AuthController extends Controller
     {
         $request = $this->runBeforeHooks($request, HookAction::OAUTH_CALLBACK);
 
-        $social_user = Socialite::driver($driver)->stateless()->user();
+        try {
+            $social_user = Socialite::driver($driver)->stateless()->user();
+        } catch (\Laravel\Socialite\Two\InvalidStateException $e) {
+            $this->error("OAuth state mismatch for {$driver}");
+
+            return $this->runAfterHooks($request, $this->failure('Invalid state. Please try again.', 400), HookAction::OAUTH_CALLBACK);
+        } catch (\GuzzleHttp\Exception\ClientException $e) {
+            $this->error("OAuth provider communication error for {$driver}: ".$e->getMessage());
+            $statusCode = in_array($e->getResponse()->getStatusCode(), [401, 403]) ? 401 : 400;
+
+            return $this->runAfterHooks($request, $this->failure('OAuth authentication failed', $statusCode), HookAction::OAUTH_CALLBACK);
+        } catch (\Exception $e) {
+            $this->error("OAuth callback failed for {$driver}: ".$e->getMessage());
+
+            return $this->runAfterHooks($request, $this->failure('OAuth authentication failed', 400), HookAction::OAUTH_CALLBACK);
+        }
+
         $email = $social_user->getEmail();
         $name = $social_user->getName();
 
@@ -195,7 +219,15 @@ class AuthController extends Controller
             return $this->runAfterHooks($request, $response, HookAction::OAUTH_CALLBACK);
         }
 
-        $existing_user = $this->handleUserAuthentication($email, $name, $driver);
+        $oauthData = [
+            'provider_id' => $social_user->getId(),
+            'avatar_url' => $social_user->getAvatar(),
+            'token' => $social_user->token,
+        ];
+
+        [$existing_user, $isNewUser] = $this->handleUserAuthentication($email, $name, $driver, $oauthData);
+
+        OauthUserAuthenticatedEvent::dispatch($existing_user, $social_user, $driver, $isNewUser);
 
         $response = [
             'user' => $existing_user,
@@ -419,7 +451,14 @@ class AuthController extends Controller
                 }
             }
 
-            $existing_user = $this->handleUserAuthentication($email, $name, $driver);
+            $oauthData = [
+                'provider_id' => $uid,
+                'avatar_url' => $user->photoUrl,
+            ];
+
+            [$existing_user, $isNewUser] = $this->handleUserAuthentication($email, $name, $driver, $oauthData);
+
+            OauthUserAuthenticatedEvent::dispatch($existing_user, null, $driver, $isNewUser);
 
             $response = [
                 'user' => $existing_user,
@@ -443,17 +482,17 @@ class AuthController extends Controller
     }
 
     /**
-     * Private helper method to handle user authentication (login/create) and OAuth account creation.
-     *
-     * @return mixed The authenticated user instance.
+     * @return array{0: mixed, 1: bool} The authenticated user instance and whether it's a new user.
      */
-    private function handleUserAuthentication(string $email, string $name, string $driver)
+    private function handleUserAuthentication(string $email, string $name, string $driver, array $oauthData = []): array
     {
         $User = config('user-authentication.user_model', User::class);
         $existing_user = $User::where('email', $email)->first();
+        $isNewUser = false;
+
         if ($existing_user) {
             UserLoggedInEvent::dispatch($existing_user);
-            $this->info("User with email $email  just logged in via social auth ");
+            $this->info("User with email $email just logged in via social auth");
         } else {
             $user_data = [
                 'first_name' => $name,
@@ -462,14 +501,16 @@ class AuthController extends Controller
                 'email_verified_at' => now(),
             ];
             $existing_user = $User::create($user_data);
+            $isNewUser = true;
             UserRegisteredEvent::dispatch($existing_user);
             $this->info("New user with email $email just registered via social auth");
         }
-        OauthAccount::firstOrCreate([
-            'user_id' => $existing_user->id,
-            'provider' => $driver,
-        ]);
 
-        return $existing_user;
+        OauthAccount::updateOrCreate(
+            ['user_id' => $existing_user->id, 'provider' => $driver],
+            $oauthData,
+        );
+
+        return [$existing_user, $isNewUser];
     }
 }

--- a/src/Models/OauthAccount.php
+++ b/src/Models/OauthAccount.php
@@ -3,8 +3,25 @@
 namespace Whilesmart\UserAuthentication\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class OauthAccount extends Model
 {
-    protected $fillable = ['user_id', 'provider'];
+    protected $fillable = ['user_id', 'provider', 'provider_id', 'avatar_url', 'token'];
+
+    protected $hidden = ['token'];
+
+    protected function casts(): array
+    {
+        return [
+            'token' => config('user-authentication.encrypt_oauth_tokens', false) ? 'encrypted' : 'string',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        $userModel = config('user-authentication.user_model', User::class);
+
+        return $this->belongsTo($userModel);
+    }
 }

--- a/tests/OauthTest.php
+++ b/tests/OauthTest.php
@@ -1,0 +1,300 @@
+<?php
+
+use Faker\Factory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Laravel\Socialite\Contracts\User as SocialiteUser;
+use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\AbstractProvider;
+use Orchestra\Testbench\Attributes\WithMigration;
+use Whilesmart\UserAuthentication\Events\OauthUserAuthenticatedEvent;
+use Whilesmart\UserAuthentication\Events\UserLoggedInEvent;
+use Whilesmart\UserAuthentication\Events\UserRegisteredEvent;
+use Whilesmart\UserAuthentication\Models\OauthAccount;
+use Whilesmart\UserAuthentication\Models\User;
+
+use function Orchestra\Testbench\workbench_path;
+
+#[WithMigration]
+class OauthTest extends \Orchestra\Testbench\TestCase
+{
+    use RefreshDatabase;
+
+    protected function defineDatabaseMigrations()
+    {
+        $this->loadMigrationsFrom(
+            workbench_path('database/migrations')
+        );
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            'Laravel\Socialite\SocialiteServiceProvider',
+            'Whilesmart\UserAuthentication\UserAuthenticationServiceProvider',
+        ];
+    }
+
+    protected function defineEnvironment($app)
+    {
+        $app['config']->set('services.github', [
+            'client_id' => 'test-client-id',
+            'client_secret' => 'test-client-secret',
+            'redirect' => 'http://localhost/auth/github/callback',
+        ]);
+    }
+
+    protected function mockSocialiteUser(array $overrides = []): SocialiteUser
+    {
+        $faker = Factory::create();
+
+        $socialiteUser = $this->createMock(SocialiteUser::class);
+        $socialiteUser->method('getId')->willReturn($overrides['id'] ?? $faker->randomNumber(8));
+        $socialiteUser->method('getName')->willReturn($overrides['name'] ?? $faker->name);
+        $socialiteUser->method('getEmail')->willReturn($overrides['email'] ?? $faker->unique()->safeEmail);
+        $socialiteUser->method('getAvatar')->willReturn($overrides['avatar'] ?? 'https://avatars.example.com/123');
+        $socialiteUser->token = $overrides['token'] ?? 'gho_fake_github_token_'.$faker->sha1;
+
+        return $socialiteUser;
+    }
+
+    protected function mockSocialiteDriver(SocialiteUser $socialiteUser): void
+    {
+        $provider = $this->createMock(AbstractProvider::class);
+        $provider->method('stateless')->willReturnSelf();
+        $provider->method('user')->willReturn($socialiteUser);
+
+        Socialite::shouldReceive('driver')
+            ->with('github')
+            ->andReturn($provider);
+    }
+
+    protected function mockSocialiteDriverWithException(\Exception $exception): void
+    {
+        $provider = $this->createMock(AbstractProvider::class);
+        $provider->method('stateless')->willReturnSelf();
+        $provider->method('user')->willThrowException($exception);
+
+        Socialite::shouldReceive('driver')
+            ->with('github')
+            ->andReturn($provider);
+    }
+
+    public function test_oauth_callback_creates_new_user_and_oauth_account()
+    {
+        Event::fake();
+
+        $socialiteUser = $this->mockSocialiteUser([
+            'id' => 12345,
+            'name' => 'Jane Doe',
+            'email' => 'jane@example.com',
+            'avatar' => 'https://avatars.example.com/jane',
+            'token' => 'gho_test_token_abc',
+        ]);
+        $this->mockSocialiteDriver($socialiteUser);
+
+        $response = $this->getJson('/api/oauth/github/callback?code=test_code');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'success',
+                'data' => [
+                    'user',
+                    'token',
+                ],
+                'message',
+            ]);
+
+        $this->assertDatabaseHas('users', ['email' => 'jane@example.com']);
+        $this->assertDatabaseHas('oauth_accounts', [
+            'provider' => 'github',
+            'provider_id' => '12345',
+            'avatar_url' => 'https://avatars.example.com/jane',
+        ]);
+
+        Event::assertDispatched(UserRegisteredEvent::class);
+        Event::assertDispatched(OauthUserAuthenticatedEvent::class, function ($event) {
+            return $event->driver === 'github'
+                && $event->isNewUser === true
+                && $event->user->email === 'jane@example.com';
+        });
+    }
+
+    public function test_oauth_callback_logs_in_existing_user_and_updates_oauth_account()
+    {
+        Event::fake();
+
+        $user = User::create([
+            'email' => 'existing@example.com',
+            'first_name' => 'Existing',
+            'password' => 'password123',
+        ]);
+
+        OauthAccount::create([
+            'user_id' => $user->id,
+            'provider' => 'github',
+            'provider_id' => '99999',
+            'avatar_url' => 'https://old-avatar.example.com',
+            'token' => 'old_token',
+        ]);
+
+        $socialiteUser = $this->mockSocialiteUser([
+            'id' => 99999,
+            'name' => 'Existing User',
+            'email' => 'existing@example.com',
+            'avatar' => 'https://new-avatar.example.com',
+            'token' => 'gho_new_token',
+        ]);
+        $this->mockSocialiteDriver($socialiteUser);
+
+        $response = $this->getJson('/api/oauth/github/callback?code=test_code');
+
+        $response->assertStatus(200);
+
+        $oauthAccount = OauthAccount::where('user_id', $user->id)->where('provider', 'github')->first();
+        $this->assertEquals('https://new-avatar.example.com', $oauthAccount->avatar_url);
+        $this->assertEquals('99999', $oauthAccount->provider_id);
+
+        Event::assertDispatched(UserLoggedInEvent::class);
+        Event::assertDispatched(OauthUserAuthenticatedEvent::class, function ($event) {
+            return $event->isNewUser === false;
+        });
+        Event::assertNotDispatched(UserRegisteredEvent::class);
+    }
+
+    public function test_oauth_callback_returns_json_error_when_provider_fails()
+    {
+        $this->mockSocialiteDriverWithException(
+            new \GuzzleHttp\Exception\ClientException(
+                'Client error',
+                new \GuzzleHttp\Psr7\Request('GET', 'https://api.github.com/user'),
+                new \GuzzleHttp\Psr7\Response(401, [], '{"message":"Bad credentials"}')
+            )
+        );
+
+        $response = $this->getJson('/api/oauth/github/callback?code=bad_code');
+
+        $response->assertStatus(401)
+            ->assertJson([
+                'success' => false,
+                'message' => 'OAuth authentication failed',
+            ]);
+    }
+
+    public function test_oauth_callback_returns_error_when_name_or_email_missing()
+    {
+        $socialiteUser = $this->mockSocialiteUser([
+            'name' => '',
+            'email' => '',
+        ]);
+        $this->mockSocialiteDriver($socialiteUser);
+
+        $response = $this->getJson('/api/oauth/github/callback?code=test_code');
+
+        $response->assertStatus(400)
+            ->assertJson([
+                'success' => false,
+                'message' => 'Your app must request the name and email of the user',
+            ]);
+    }
+
+    public function test_oauth_login_uses_configured_scopes()
+    {
+        config(['user-authentication.oauth_scopes.github' => ['read:user', 'user:email', 'repo']]);
+
+        $provider = $this->createMock(AbstractProvider::class);
+        $provider->method('stateless')->willReturnSelf();
+        $provider->expects($this->once())
+            ->method('scopes')
+            ->with(['read:user', 'user:email', 'repo'])
+            ->willReturnSelf();
+
+        $redirectResponse = new \Illuminate\Http\RedirectResponse('https://github.com/login/oauth/authorize?scope=read:user+user:email+repo');
+        $provider->method('redirect')->willReturn($redirectResponse);
+
+        Socialite::shouldReceive('driver')
+            ->with('github')
+            ->andReturn($provider);
+
+        $response = $this->getJson('/api/oauth/github/login');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'success',
+                'data' => ['url'],
+            ]);
+    }
+
+    public function test_oauth_login_works_without_configured_scopes()
+    {
+        config(['user-authentication.oauth_scopes' => []]);
+
+        $provider = $this->createMock(AbstractProvider::class);
+        $provider->method('stateless')->willReturnSelf();
+        $provider->expects($this->never())->method('scopes');
+
+        $redirectResponse = new \Illuminate\Http\RedirectResponse('https://github.com/login/oauth/authorize');
+        $provider->method('redirect')->willReturn($redirectResponse);
+
+        Socialite::shouldReceive('driver')
+            ->with('github')
+            ->andReturn($provider);
+
+        $response = $this->getJson('/api/oauth/github/login');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_oauth_callback_stores_provider_data_on_oauth_account()
+    {
+        Event::fake();
+
+        $socialiteUser = $this->mockSocialiteUser([
+            'id' => 77777,
+            'email' => 'provider-data@example.com',
+            'name' => 'Test User',
+            'avatar' => 'https://avatars.example.com/77777',
+            'token' => 'gho_provider_token_xyz',
+        ]);
+        $this->mockSocialiteDriver($socialiteUser);
+
+        $this->getJson('/api/oauth/github/callback?code=test_code');
+
+        $user = User::where('email', 'provider-data@example.com')->first();
+        $this->assertNotNull($user);
+
+        $oauthAccount = OauthAccount::where('user_id', $user->id)->where('provider', 'github')->first();
+        $this->assertNotNull($oauthAccount);
+        $this->assertEquals('77777', $oauthAccount->provider_id);
+        $this->assertEquals('https://avatars.example.com/77777', $oauthAccount->avatar_url);
+        $this->assertEquals('gho_provider_token_xyz', $oauthAccount->token);
+    }
+
+    public function test_oauth_callback_does_not_create_duplicate_oauth_accounts()
+    {
+        Event::fake();
+
+        $email = 'nodupe@example.com';
+        $user = User::create([
+            'email' => $email,
+            'first_name' => 'No Dupe',
+            'password' => 'password123',
+        ]);
+        OauthAccount::create([
+            'user_id' => $user->id,
+            'provider' => 'github',
+            'provider_id' => '55555',
+        ]);
+
+        $socialiteUser = $this->mockSocialiteUser([
+            'id' => 55555,
+            'email' => $email,
+            'name' => 'No Dupe',
+        ]);
+        $this->mockSocialiteDriver($socialiteUser);
+
+        $this->getJson('/api/oauth/github/callback?code=test_code');
+
+        $this->assertEquals(1, OauthAccount::where('user_id', $user->id)->where('provider', 'github')->count());
+    }
+}


### PR DESCRIPTION
- Add provider_id, avatar_url, and encrypted token columns to oauth_accounts
- Add oauth_scopes config option per driver for customizable OAuth scopes
- Add OauthUserAuthenticatedEvent dispatched after OAuth login with social user data
- Add error handling around Socialite callback to return JSON on failure
- Add user() relationship and hidden/encrypted token on OauthAccount model
- Update handleUserAuthentication to accept optional OAuth data and return isNewUser flag