### PR TITLE
feat(docs): Add docs-kit integration

### DIFF
--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -1,0 +1,20 @@
+name: Validate Docs
+
+on:
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'docs/**'
+      - 'docs.json'
+  push:
+    branches: [main, dev]
+    paths:
+      - 'docs/**'
+      - 'docs.json'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: whilesmart/docs-kit/.github/actions/validate-docs@main

--- a/docs.json
+++ b/docs.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://raw.githubusercontent.com/whilesmart/docs-kit/main/schema/docs.schema.json",
+  "name": "Laravel User Authentication",
+  "description": "A comprehensive Laravel package for user authentication with registration, login, password reset, OAuth, and configurable email/phone verification",
+  "icon": "shield-check",
+  "category": {
+    "language": "php",
+    "framework": "laravel"
+  },
+  "sidebar": [
+    { "title": "Installation", "path": "docs/installation.md" },
+    { "title": "Verification", "path": "docs/verification.md" },
+    { "title": "Customization", "path": "docs/customization.md" }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `docs.json` manifest following the [whilesmart/docs-kit](https://github.com/whilesmart/docs-kit) standard, pointing to existing documentation files (`installation.md`, `verification.md`, `customization.md`)
- Adds `validate-docs.yml` GitHub Actions workflow that runs the docs-kit validator on PRs/pushes when docs or manifest change

## Test plan

- [ ] Verify `docs.json` is valid against the docs-kit schema (`npx @whilesmart/docs-cli validate`)
- [ ] Verify the GitHub Action triggers correctly on docs changes
- [ ] Confirm all sidebar paths in `docs.json` reference existing files