### PR TITLE
feat: Add passkey feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor/
 workbench/storage
 docs/api.json
 reports/
+demo/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,83 @@
+# AGENTS.md — whilesmart/laravel-user-authentication
+
+This is a **Laravel package** (not a standalone app). Tests use **Orchestra Testbench**.
+
+## Quick commands
+
+| Command | What it does |
+|---------|-------------|
+| `composer test` | Run all tests with coverage |
+| `composer pint` | Format code (PSR-12 preset — **not** the Laravel preset) |
+| `composer pint:test` | Check formatting only |
+| `composer phpstan` | Static analysis, level 5 (`src/`, 2048M memory) |
+| `composer phpmd` | Mess detection on `src/` |
+| `composer phpcs:test` | PHPCS check on `src/` |
+| `composer openapi` | Generate `docs/api.json` from PHP attributes |
+| `composer serve` | Build workbench + start dev server |
+
+**Lint pipeline order:** `pint:test` → `phpcs:test` → `phpstan` → `phpmd`
+
+## Docker dev (alternative to direct composer)
+
+```bash
+make up         # docker compose up -d
+make install    # up + composer install
+make test       # test in container
+make lint       # pint + phpcs + phpstan + phpmd
+make shell      # bash in container
+make fresh      # down + up + install
+```
+
+## Architecture
+
+- **Namespace:** `Whilesmart\UserAuthentication\` → `src/`
+- **Test namespace:** `Whilesmart\UserAuthentication\Tests\` → `tests/`
+- **Service provider:** `UserAuthenticationServiceProvider` — auto-loads routes, migrations, translations, publishes config/docs/controllers
+- **Routes auto-register** under `USER_AUTH_ROUTE_PREFIX` (default: `api`). Disable via config keys `register_routes` / `register_oauth_routes`.
+- **Config:** All env-driven with `USER_AUTH_*` prefix, published to `config/user-authentication.php`
+- **Test base class:** `tests/TestCase.php` — extends `Orchestra\Testbench\TestCase`, uses `RefreshDatabase`, loads `SocialiteServiceProvider`, creates users via `createUser()` helper
+- **Key deps:** Sanctum (API tokens), Socialite (OAuth), kreait/laravel-firebase, web-auth/webauthn-lib, smartpings/php-sdk
+- **User model:** `src/Models/User.php` — uses `HasApiTokens`, `HasPasskeys`
+
+## Package structure
+
+| Directory | Purpose |
+|-----------|---------|
+| `src/Http/Controllers/Auth/` | `AuthController`, `PasskeyController`, `PasswordResetController` |
+| `src/Models/` | `User`, `VerificationCode`, `OauthAccount`, `Passkey` |
+| `src/Services/` | `SmartPingsVerificationService`, `PasskeyService` |
+| `src/Events/` | 7 events (register, login, logout, verification, password reset, OAuth) |
+| `src/Traits/` | `ApiResponse`, `HasMiddlewareHooks`, `HasPasskeys`, `Loggable` |
+| `config/` | `user-authentication.php` |
+| `routes/` | `user-authentication.php` (auth + passkey), `social-login.php` (OAuth) |
+
+## Key quirks
+
+- **Pint uses PSR-12** (`--preset psr12`), not the default Laravel preset
+- **PHPStan level 5** — run on `src/` only, includes Larastan + Carbon extensions
+- **Tests use SQLite** (Testbench default), but Docker env spins up MySQL
+- **Migrations load from two places:** package's `database/migrations/` and `workbench/database/migrations/` (for test schema)
+- **OAuth callback** supports both GET and POST (`Route::match`)
+- **Firebase OAuth** uses a dedicated endpoint `/oauth/firebase/{driver}/callback`
+- **Passkey session** is stored in cache, configurable lifetime
+- **Passkey origin/rp config** requires `USER_AUTH_PASSKEY_ALLOWED_ORIGINS` set to the full origin(s) where the frontend is served (e.g. `https://app.example.com`). `USER_AUTH_PASSKEY_DOMAIN` must also include the scheme (e.g. `https://app.example.com`) because the backend extracts the host with `parse_url()`; a bare hostname causes `rp.id` to be dropped and an **rpId hash mismatch** during registration
+- **Passkey resident keys** are opt-in via `USER_AUTH_PASSKEY_RESIDENT_KEYS`. Required for passwordless login without email; disabled by default
+- **Email restrictions** support whitelist/blacklist mode via env vars
+
+## Commits
+
+Conventional commit prefixes — short, lowercase, no trailing `.`:
+
+```
+feat:       New feature
+enh:        Enhancement to existing feature
+fix:        Bug fix
+chore:      Tooling, deps, CI, refactors with no behaviour change
+docs:       Documentation only
+```
+
+Use scopes for context when helpful: `feat(oauth):`, `feat(docs):`, `chore(deps):`.
+
+**Capitalize the first word after the colon:** `feat: Add feature`, not `feat: add feature`.
+
+**Do not commit** unless explicitly asked. Before committing, inspect `git status`, `git diff`, and recent log; stage only intended files.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ class SendVerificationCodeEmailListener {
 
 The package supports WebAuthn passkeys for passwordless and email-based login. Enable `USER_AUTH_PASSKEY_RESIDENT_KEYS` to register discoverable credentials that can be used without entering an email first.
 
+If you use a custom user model, add the `Whilesmart\UserAuthentication\Traits\HasPasskeys` trait to it so the passkey polymorphic relation is available.
+
 ```bash
 # .env
 USER_AUTH_PASSKEY_ALLOWED_ORIGINS=https://app.example.com

--- a/README.md
+++ b/README.md
@@ -9,7 +9,12 @@ A comprehensive Laravel authentication package with support for registration, lo
   * Login with email, phone, or username
   * Password reset functionality
   * OAuth integration (Google, Apple, etc.)
-  
+
+* **Passkey Authentication:**
+  * WebAuthn passwordless login
+  * Email-based passkey login
+  * Discoverable / resident credential registration
+
 * **Email/Phone Verification:**
   * Configurable verification before registration
   * Event-driven integration with any email/SMS provider
@@ -90,6 +95,23 @@ class SendVerificationCodeEmailListener {
 
 **📖 [Complete Verification Setup Guide](docs/verification.md)**
 
+## Passkey Authentication
+
+The package supports WebAuthn passkeys for passwordless and email-based login. Enable `USER_AUTH_PASSKEY_RESIDENT_KEYS` to register discoverable credentials that can be used without entering an email first.
+
+```bash
+# .env
+USER_AUTH_PASSKEY_ALLOWED_ORIGINS=https://app.example.com
+USER_AUTH_PASSKEY_DOMAIN=https://app.example.com
+USER_AUTH_PASSKEY_RESIDENT_KEYS=true
+USER_AUTH_PASSKEY_ATTESTATIONS=none
+USER_AUTH_PASSKEY_SESSION_LIFETIME=5
+```
+
+`USER_AUTH_PASSKEY_DOMAIN` must include the scheme (e.g. `https://app.example.com`) because the backend extracts the RP ID host with `parse_url()`. A bare hostname will cause an **"rpId hash mismatch"** error.
+
+**📖 [Passkey Guide](docs/passkey.md)**
+
 ## Environment Variables
 
 All package configuration is now environment-driven. Add these variables to your `.env` file:
@@ -135,6 +157,24 @@ SMARTPINGS_CLIENT_ID=your-client-id
 SMARTPINGS_SECRET_ID=your-secret-id
 ```
 
+### Passkey Settings
+```bash
+# Full frontend origin(s) allowed to perform WebAuthn ceremonies
+USER_AUTH_PASSKEY_ALLOWED_ORIGINS=https://app.example.com
+
+# Relying party domain. Must include the scheme.
+USER_AUTH_PASSKEY_DOMAIN=https://app.example.com
+
+# Attestation formats: none, packed, fido (default: none)
+USER_AUTH_PASSKEY_ATTESTATIONS=none
+
+# Challenge cache lifetime in minutes (default: 5)
+USER_AUTH_PASSKEY_SESSION_LIFETIME=5
+
+# Request discoverable (resident) credentials. Required for passwordless login without email.
+USER_AUTH_PASSKEY_RESIDENT_KEYS=false
+```
+
 ## Available Endpoints
 
 * `POST /api/register` - Register a new user
@@ -147,6 +187,12 @@ SMARTPINGS_SECRET_ID=your-secret-id
 * `GET /api/oauth/{provider}/login` - OAuth login
 * `GET /api/oauth/{provider}/callback` - OAuth callback
 * `POST /api/oauth/firebase/{provider}/callback` - Firebase OAuth callback. See the [Laravel Firebase Package](https://github.com/kreait/laravel-firebase) for Firebase configurations.
+* `POST /api/passkeys/register/options` - Get passkey registration options (auth required)
+* `POST /api/passkeys/register` - Register a passkey (auth required)
+* `POST /api/passkeys/login/options` - Get passkey login options
+* `POST /api/passkeys/login` - Login with a passkey
+* `GET /api/passkeys` - List user passkeys (auth required)
+* `DELETE /api/passkeys/{id}` - Delete a passkey (auth required)
 
 ## Events
 
@@ -189,6 +235,7 @@ Please see the steps [outlined here](https://socialiteproviders.com/Apple/#insta
 
 * **📖 [Installation Guide](docs/installation.md)** - Complete installation instructions
 * **📖 [Email/Phone Verification](docs/verification.md)** - Set up verification with any provider
+* **📖 [Passkey Authentication](docs/passkey.md)** - WebAuthn passkey setup and troubleshooting
 * **📖 [Customization Guide](docs/customization.md)** - Response formatting, middleware hooks
 
 ## Development Commands

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
     "laravel/socialite": "^5.23",
     "smartpings/php-sdk": "dev-main",
     "kreait/laravel-firebase": "^6.1",
-    "socialiteproviders/apple": "^5.8"
+    "socialiteproviders/apple": "^5.8",
+    "web-auth/webauthn-lib": "^5.0"
   },
   "autoload-dev": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "82c5751e15ee81497ef5ecbfb22d0f74",
+    "content-hash": "d30c0ce1cd2d94fd1c1c286256b3c5d1",
     "packages": [
         {
             "name": "beste/clock",
@@ -76,20 +76,20 @@
         },
         {
             "name": "beste/in-memory-cache",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/beste/in-memory-cache-php.git",
-                "reference": "1b9fbfcfbd0b657b90a759ac41b22748501c7f0e"
+                "reference": "d6991967b05e820cb1bcd2d31ca11ea8b1ca3f77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/beste/in-memory-cache-php/zipball/1b9fbfcfbd0b657b90a759ac41b22748501c7f0e",
-                "reference": "1b9fbfcfbd0b657b90a759ac41b22748501c7f0e",
+                "url": "https://api.github.com/repos/beste/in-memory-cache-php/zipball/d6991967b05e820cb1bcd2d31ca11ea8b1ca3f77",
+                "reference": "d6991967b05e820cb1bcd2d31ca11ea8b1ca3f77",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
                 "psr/cache": "^2.0 || ^3.0",
                 "psr/clock": "^1.0"
             },
@@ -98,15 +98,14 @@
             },
             "require-dev": {
                 "beste/clock": "^3.0",
-                "beste/php-cs-fixer-config": "^3.2.0",
-                "friendsofphp/php-cs-fixer": "^3.62.0",
-                "phpstan/extension-installer": "^1.4.1",
-                "phpstan/phpstan": "^2.0.1",
-                "phpstan/phpstan-deprecation-rules": "^2.0",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^10.5.2 || ^11.3.1",
-                "symfony/var-dumper": "^6.4 || ^7.1.3"
+                "friendsofphp/php-cs-fixer": "^3.95.1",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^2.1.51",
+                "phpstan/phpstan-deprecation-rules": "^2.0.4",
+                "phpstan/phpstan-phpunit": "^2.0.16",
+                "phpstan/phpstan-strict-rules": "^2.0.10",
+                "phpunit/phpunit": "^12.5.23",
+                "symfony/var-dumper": "^7.4.8 || ^v8.0.8"
             },
             "suggest": {
                 "psr/clock-implementation": "Allows injecting a Clock, for example a frozen clock for testing"
@@ -135,15 +134,9 @@
             ],
             "support": {
                 "issues": "https://github.com/beste/in-memory-cache-php/issues",
-                "source": "https://github.com/beste/in-memory-cache-php/tree/1.4.0"
+                "source": "https://github.com/beste/in-memory-cache-php/tree/1.5.0"
             },
-            "funding": [
-                {
-                    "url": "https://github.com/jeromegamez",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-09-29T22:05:17+00:00"
+            "time": "2026-04-27T12:29:41+00:00"
         },
         {
             "name": "beste/json",
@@ -339,16 +332,16 @@
         },
         {
             "name": "cuyz/valinor",
-            "version": "2.3.2",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CuyZ/Valinor.git",
-                "reference": "3b9f3f54901371d589776502aab3da3a046801a7"
+                "reference": "3b0afa3a287ed7f3a69aab223726cf1139454c34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CuyZ/Valinor/zipball/3b9f3f54901371d589776502aab3da3a046801a7",
-                "reference": "3b9f3f54901371d589776502aab3da3a046801a7",
+                "url": "https://api.github.com/repos/CuyZ/Valinor/zipball/3b0afa3a287ed7f3a69aab223726cf1139454c34",
+                "reference": "3b0afa3a287ed7f3a69aab223726cf1139454c34",
                 "shasum": ""
             },
             "require": {
@@ -360,14 +353,15 @@
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^3.91",
-                "infection/infection": "^0.31",
+                "infection/infection": "^0.32",
                 "marcocesarato/php-conventional-changelog": "^1.12",
                 "mikey179/vfsstream": "^1.6.10",
                 "phpbench/phpbench": "^1.3",
                 "phpstan/phpstan": "^2.0",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^10.5",
+                "phpunit/phpunit": "^11.5",
+                "psr/http-message": "^2.0",
                 "rector/rector": "^2.0",
                 "vimeo/psalm": "^6.0"
             },
@@ -403,7 +397,7 @@
             ],
             "support": {
                 "issues": "https://github.com/CuyZ/Valinor/issues",
-                "source": "https://github.com/CuyZ/Valinor/tree/2.3.2"
+                "source": "https://github.com/CuyZ/Valinor/tree/2.4.0"
             },
             "funding": [
                 {
@@ -411,7 +405,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-23T15:26:34+00:00"
+            "time": "2026-03-23T17:38:05+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -487,6 +481,54 @@
                 "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.3"
             },
             "time": "2024-07-08T12:26:09+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "1.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=14"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
+            },
+            "time": "2026-02-07T07:09:04+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -844,16 +886,16 @@
         },
         {
             "name": "firebase/php-jwt",
-            "version": "v6.11.1",
+            "version": "v7.0.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66"
+                "url": "https://github.com/googleapis/php-jwt.git",
+                "reference": "47ad26bab5e7c70ae8a6f08ed25ff83631121380"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
-                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/47ad26bab5e7c70ae8a6f08ed25ff83631121380",
+                "reference": "47ad26bab5e7c70ae8a6f08ed25ff83631121380",
                 "shasum": ""
             },
             "require": {
@@ -861,6 +903,7 @@
             },
             "require-dev": {
                 "guzzlehttp/guzzle": "^7.4",
+                "phpfastcache/phpfastcache": "^9.2",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5",
                 "psr/cache": "^2.0||^3.0",
@@ -900,10 +943,10 @@
                 "php"
             ],
             "support": {
-                "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.11.1"
+                "issues": "https://github.com/googleapis/php-jwt/issues",
+                "source": "https://github.com/googleapis/php-jwt/tree/v7.0.5"
             },
-            "time": "2025-04-09T20:32:01+00:00"
+            "time": "2026-04-01T20:38:03+00:00"
         },
         {
             "name": "fruitcake/php-cors",
@@ -978,16 +1021,16 @@
         },
         {
             "name": "google/auth",
-            "version": "v1.50.0",
+            "version": "v1.50.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-auth-library-php.git",
-                "reference": "e1c26a718198e16d8a3c69b1cae136b73f959b0f"
+                "reference": "870c17ee3a1d73338d39a9ffa77a700ba77f5a83"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/e1c26a718198e16d8a3c69b1cae136b73f959b0f",
-                "reference": "e1c26a718198e16d8a3c69b1cae136b73f959b0f",
+                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/870c17ee3a1d73338d39a9ffa77a700ba77f5a83",
+                "reference": "870c17ee3a1d73338d39a9ffa77a700ba77f5a83",
                 "shasum": ""
             },
             "require": {
@@ -997,7 +1040,7 @@
                 "php": "^8.1",
                 "psr/cache": "^2.0||^3.0",
                 "psr/http-message": "^1.1||^2.0",
-                "psr/log": "^3.0"
+                "psr/log": "^2.0||^3.0"
             },
             "require-dev": {
                 "guzzlehttp/promises": "^2.0",
@@ -1034,22 +1077,22 @@
             "support": {
                 "docs": "https://cloud.google.com/php/docs/reference/auth/latest",
                 "issues": "https://github.com/googleapis/google-auth-library-php/issues",
-                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.50.0"
+                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.50.1"
             },
-            "time": "2026-01-08T21:33:57+00:00"
+            "time": "2026-03-18T20:03:29+00:00"
         },
         {
             "name": "google/cloud-core",
-            "version": "v1.71.1",
+            "version": "v1.72.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-cloud-php-core.git",
-                "reference": "b170c5d2095f05def125a1f7452f7fcca0a9ffaf"
+                "reference": "aa7869016cb9e87e95071bb92579fd22146ababb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-cloud-php-core/zipball/b170c5d2095f05def125a1f7452f7fcca0a9ffaf",
-                "reference": "b170c5d2095f05def125a1f7452f7fcca0a9ffaf",
+                "url": "https://api.github.com/repos/googleapis/google-cloud-php-core/zipball/aa7869016cb9e87e95071bb92579fd22146ababb",
+                "reference": "aa7869016cb9e87e95071bb92579fd22146ababb",
                 "shasum": ""
             },
             "require": {
@@ -1065,7 +1108,7 @@
             },
             "require-dev": {
                 "erusev/parsedown": "^1.6",
-                "google/cloud-common-protos": "~0.5",
+                "google/cloud-common-protos": "~0.5||^1.0",
                 "nikic/php-parser": "^5.6",
                 "opis/closure": "^3.7|^4.0",
                 "phpdocumentor/reflection": "^6.0",
@@ -1101,34 +1144,35 @@
             ],
             "description": "Google Cloud PHP shared dependency, providing functionality useful to all components.",
             "support": {
-                "source": "https://github.com/googleapis/google-cloud-php-core/tree/v1.71.1"
+                "source": "https://github.com/googleapis/google-cloud-php-core/tree/v1.72.1"
             },
-            "time": "2026-01-23T22:57:13+00:00"
+            "time": "2026-05-12T19:06:48+00:00"
         },
         {
             "name": "google/cloud-storage",
-            "version": "v1.49.2",
+            "version": "v1.51.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-cloud-php-storage.git",
-                "reference": "1cab44377fc65c7feba1f706970f3abf5ccba392"
+                "reference": "9ba3d5e8cbd53bf67fab644b5be310e719533def"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-cloud-php-storage/zipball/1cab44377fc65c7feba1f706970f3abf5ccba392",
-                "reference": "1cab44377fc65c7feba1f706970f3abf5ccba392",
+                "url": "https://api.github.com/repos/googleapis/google-cloud-php-storage/zipball/9ba3d5e8cbd53bf67fab644b5be310e719533def",
+                "reference": "9ba3d5e8cbd53bf67fab644b5be310e719533def",
                 "shasum": ""
             },
             "require": {
-                "google/cloud-core": "^1.57",
+                "google/cloud-core": "^1.72.0",
                 "php": "^8.1",
                 "ramsey/uuid": "^4.2.3"
             },
             "require-dev": {
                 "erusev/parsedown": "^1.6",
                 "google/cloud-pubsub": "^2.0",
-                "phpdocumentor/reflection": "^5.3.3||^6.0",
-                "phpdocumentor/reflection-docblock": "^5.3.3||^6.0",
+                "nikic/php-parser": "^5",
+                "phpdocumentor/reflection": "^6.0",
+                "phpdocumentor/reflection-docblock": "^5.3.3",
                 "phpseclib/phpseclib": "^2.0||^3.0",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.0",
@@ -1158,26 +1202,26 @@
             ],
             "description": "Cloud Storage Client for PHP",
             "support": {
-                "source": "https://github.com/googleapis/google-cloud-php-storage/tree/v1.49.2"
+                "source": "https://github.com/googleapis/google-cloud-php-storage/tree/v1.51.0"
             },
-            "time": "2026-01-23T22:57:13+00:00"
+            "time": "2026-04-09T21:01:46+00:00"
         },
         {
             "name": "google/common-protos",
-            "version": "4.12.4",
+            "version": "4.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/common-protos-php.git",
-                "reference": "0127156899af0df2681bd42024c60bd5360d64e3"
+                "reference": "f8e72f7b581702e7c3ee0776144f4974da172428"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/common-protos-php/zipball/0127156899af0df2681bd42024c60bd5360d64e3",
-                "reference": "0127156899af0df2681bd42024c60bd5360d64e3",
+                "url": "https://api.github.com/repos/googleapis/common-protos-php/zipball/f8e72f7b581702e7c3ee0776144f4974da172428",
+                "reference": "f8e72f7b581702e7c3ee0776144f4974da172428",
                 "shasum": ""
             },
             "require": {
-                "google/protobuf": "^4.31",
+                "google/protobuf": "^4.31||^5.0",
                 "php": "^8.1"
             },
             "require-dev": {
@@ -1217,22 +1261,22 @@
                 "google"
             ],
             "support": {
-                "source": "https://github.com/googleapis/common-protos-php/tree/v4.12.4"
+                "source": "https://github.com/googleapis/common-protos-php/tree/v4.14.0"
             },
-            "time": "2025-09-20T01:29:44+00:00"
+            "time": "2026-04-09T21:01:46+00:00"
         },
         {
             "name": "google/gax",
-            "version": "v1.42.0",
+            "version": "v1.42.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/gax-php.git",
-                "reference": "7ad13e5b9ca201a5f60e7b3342842d1217bc23a6"
+                "reference": "9b1f5fb68960a9020e34fdb88583bcd43779e4fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/gax-php/zipball/7ad13e5b9ca201a5f60e7b3342842d1217bc23a6",
-                "reference": "7ad13e5b9ca201a5f60e7b3342842d1217bc23a6",
+                "url": "https://api.github.com/repos/googleapis/gax-php/zipball/9b1f5fb68960a9020e34fdb88583bcd43779e4fd",
+                "reference": "9b1f5fb68960a9020e34fdb88583bcd43779e4fd",
                 "shasum": ""
             },
             "require": {
@@ -1240,7 +1284,7 @@
                 "google/common-protos": "^4.4",
                 "google/grpc-gcp": "^0.4",
                 "google/longrunning": "~0.4",
-                "google/protobuf": "^4.31",
+                "google/protobuf": "^4.31||^5.34",
                 "grpc/grpc": "^1.13",
                 "guzzlehttp/promises": "^2.0",
                 "guzzlehttp/psr7": "^2.0",
@@ -1251,10 +1295,10 @@
                 "ext-protobuf": "<4.31.0"
             },
             "require-dev": {
+                "google/cloud-tools": "^0.16.1",
                 "phpspec/prophecy-phpunit": "^2.1",
                 "phpstan/phpstan": "^2.0",
-                "phpunit/phpunit": "^9.6",
-                "squizlabs/php_codesniffer": "4.*"
+                "phpunit/phpunit": "^9.6"
             },
             "type": "library",
             "autoload": {
@@ -1274,27 +1318,27 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/gax-php/issues",
-                "source": "https://github.com/googleapis/gax-php/tree/v1.42.0"
+                "source": "https://github.com/googleapis/gax-php/tree/v1.42.4"
             },
-            "time": "2026-01-22T20:31:50+00:00"
+            "time": "2026-05-11T17:49:55+00:00"
         },
         {
             "name": "google/grpc-gcp",
-            "version": "v0.4.1",
+            "version": "0.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/GoogleCloudPlatform/grpc-gcp-php.git",
-                "reference": "e585b7721bbe806ef45b5c52ae43dfc2bff89968"
+                "reference": "1049c0c15b6a1789fdeb52af688a94d540932469"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GoogleCloudPlatform/grpc-gcp-php/zipball/e585b7721bbe806ef45b5c52ae43dfc2bff89968",
-                "reference": "e585b7721bbe806ef45b5c52ae43dfc2bff89968",
+                "url": "https://api.github.com/repos/GoogleCloudPlatform/grpc-gcp-php/zipball/1049c0c15b6a1789fdeb52af688a94d540932469",
+                "reference": "1049c0c15b6a1789fdeb52af688a94d540932469",
                 "shasum": ""
             },
             "require": {
                 "google/auth": "^1.3",
-                "google/protobuf": "^v3.25.3||^4.26.1",
+                "google/protobuf": "^v3.25.3||^4.26.1||^5.0",
                 "grpc/grpc": "^v1.13.0",
                 "php": "^8.0",
                 "psr/cache": "^1.0.1||^2.0.0||^3.0.0"
@@ -1319,22 +1363,22 @@
             "description": "gRPC GCP library for channel management",
             "support": {
                 "issues": "https://github.com/GoogleCloudPlatform/grpc-gcp-php/issues",
-                "source": "https://github.com/GoogleCloudPlatform/grpc-gcp-php/tree/v0.4.1"
+                "source": "https://github.com/GoogleCloudPlatform/grpc-gcp-php/tree/v0.4.2"
             },
-            "time": "2025-02-19T21:53:22+00:00"
+            "time": "2026-03-12T22:56:09+00:00"
         },
         {
             "name": "google/longrunning",
-            "version": "0.6.0",
+            "version": "0.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/php-longrunning.git",
-                "reference": "226d3b5166eaa13754cc5e452b37872478e23375"
+                "reference": "cac9bedf199239ae2b1acd4a8e4ea2276bd9f55a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/php-longrunning/zipball/226d3b5166eaa13754cc5e452b37872478e23375",
-                "reference": "226d3b5166eaa13754cc5e452b37872478e23375",
+                "url": "https://api.github.com/repos/googleapis/php-longrunning/zipball/cac9bedf199239ae2b1acd4a8e4ea2276bd9f55a",
+                "reference": "cac9bedf199239ae2b1acd4a8e4ea2276bd9f55a",
                 "shasum": ""
             },
             "require-dev": {
@@ -1363,29 +1407,29 @@
             ],
             "description": "Google LongRunning Client for PHP",
             "support": {
-                "source": "https://github.com/googleapis/php-longrunning/tree/v0.6.0"
+                "source": "https://github.com/googleapis/php-longrunning/tree/v0.7.1"
             },
-            "time": "2025-10-07T18:41:09+00:00"
+            "time": "2026-03-31T19:52:22+00:00"
         },
         {
             "name": "google/protobuf",
-            "version": "v4.33.5",
+            "version": "v5.35.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/protocolbuffers/protobuf-php.git",
-                "reference": "ebe8010a61b2ae0cff0d246fe1c4d44e9f7dfa6d"
+                "reference": "d96ed77c7edaff3cd576a74173aa0b0655c87b1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/ebe8010a61b2ae0cff0d246fe1c4d44e9f7dfa6d",
-                "reference": "ebe8010a61b2ae0cff0d246fe1c4d44e9f7dfa6d",
+                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/d96ed77c7edaff3cd576a74173aa0b0655c87b1a",
+                "reference": "d96ed77c7edaff3cd576a74173aa0b0655c87b1a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1.0"
+                "php": ">=8.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": ">=5.0.0 <8.5.27"
+                "phpunit/phpunit": ">=11.5.0 <12.0.0"
             },
             "suggest": {
                 "ext-bcmath": "Need to support JSON deserialization"
@@ -1407,9 +1451,9 @@
                 "proto"
             ],
             "support": {
-                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v4.33.5"
+                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v5.35.0"
             },
-            "time": "2026-01-29T20:49:00+00:00"
+            "time": "2026-05-19T22:13:40+00:00"
         },
         {
             "name": "graham-campbell/result-type",
@@ -1475,20 +1519,20 @@
         },
         {
             "name": "grpc/grpc",
-            "version": "1.74.0",
+            "version": "1.80.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/grpc/grpc-php.git",
-                "reference": "32bf4dba256d60d395582fb6e4e8d3936bcdb713"
+                "reference": "a0dc463d5d5064cdd7ff344f13f61d7e233f9b5a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/grpc/grpc-php/zipball/32bf4dba256d60d395582fb6e4e8d3936bcdb713",
-                "reference": "32bf4dba256d60d395582fb6e4e8d3936bcdb713",
+                "url": "https://api.github.com/repos/grpc/grpc-php/zipball/a0dc463d5d5064cdd7ff344f13f61d7e233f9b5a",
+                "reference": "a0dc463d5d5064cdd7ff344f13f61d7e233f9b5a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0.0"
+                "php": ">=7.1.0"
             },
             "require-dev": {
                 "google/auth": "^v1.3.0"
@@ -1513,22 +1557,22 @@
                 "rpc"
             ],
             "support": {
-                "source": "https://github.com/grpc/grpc-php/tree/v1.74.0"
+                "source": "https://github.com/grpc/grpc-php/tree/v1.80.0"
             },
-            "time": "2025-07-24T20:02:16+00:00"
+            "time": "2026-03-30T09:22:39+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "version": "7.10.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "7c8d84b39e680315f687e8662a9d6fb0865c5148"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7c8d84b39e680315f687e8662a9d6fb0865c5148",
+                "reference": "7c8d84b39e680315f687e8662a9d6fb0865c5148",
                 "shasum": ""
             },
             "require": {
@@ -1546,8 +1590,9 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
+                "guzzlehttp/test-server": "^0.4",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -1625,7 +1670,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.10.5"
             },
             "funding": [
                 {
@@ -1641,20 +1686,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-05-27T11:53:46+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.0",
+            "version": "2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "09e8a212562fb1fb6a512c4156ed71525969d6c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/09e8a212562fb1fb6a512c4156ed71525969d6c2",
+                "reference": "09e8a212562fb1fb6a512c4156ed71525969d6c2",
                 "shasum": ""
             },
             "require": {
@@ -1662,7 +1707,7 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -1708,7 +1753,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/2.4.1"
             },
             "funding": [
                 {
@@ -1724,20 +1769,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-05-20T22:57:30+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.8.0",
+            "version": "2.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "21dc724a0583619cd1652f673303492272778051"
+                "reference": "7c1472269227dc6f18930bd903d7a88fe6c52130"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
-                "reference": "21dc724a0583619cd1652f673303492272778051",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7c1472269227dc6f18930bd903d7a88fe6c52130",
+                "reference": "7c1472269227dc6f18930bd903d7a88fe6c52130",
                 "shasum": ""
             },
             "require": {
@@ -1752,8 +1797,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "http-interop/http-factory-tests": "1.1.0",
+                "jshttp/mime-db": "1.54.0.1",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -1824,7 +1870,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.10.3"
             },
             "funding": [
                 {
@@ -1840,20 +1886,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T21:21:41+00:00"
+            "time": "2026-05-27T11:48:20+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
-            "version": "v1.0.5",
+            "version": "v1.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/uri-template.git",
-                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1"
+                "reference": "eef7f87bab6f204eba3c39224d8075c70c637946"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/4f4bbd4e7172148801e76e3decc1e559bdee34e1",
-                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1",
+                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/eef7f87bab6f204eba3c39224d8075c70c637946",
+                "reference": "eef7f87bab6f204eba3c39224d8075c70c637946",
                 "shasum": ""
             },
             "require": {
@@ -1862,7 +1908,7 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "uri-template/tests": "1.0.0"
             },
             "type": "library",
@@ -1910,7 +1956,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/uri-template/issues",
-                "source": "https://github.com/guzzle/uri-template/tree/v1.0.5"
+                "source": "https://github.com/guzzle/uri-template/tree/v1.0.6"
             },
             "funding": [
                 {
@@ -1926,20 +1972,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:27:06+00:00"
+            "time": "2026-05-23T22:00:21+00:00"
         },
         {
             "name": "kreait/firebase-php",
-            "version": "7.24.0",
+            "version": "7.24.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/beste/firebase-php.git",
-                "reference": "7e2c321265dcb2eeea6fdb72e3819db684e0d4be"
+                "reference": "935292e2af33af0120654ce704f1dc8f1c03025b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/beste/firebase-php/zipball/7e2c321265dcb2eeea6fdb72e3819db684e0d4be",
-                "reference": "7e2c321265dcb2eeea6fdb72e3819db684e0d4be",
+                "url": "https://api.github.com/repos/beste/firebase-php/zipball/935292e2af33af0120654ce704f1dc8f1c03025b",
+                "reference": "935292e2af33af0120654ce704f1dc8f1c03025b",
                 "shasum": ""
             },
             "require": {
@@ -1952,7 +1998,7 @@
                 "ext-json": "*",
                 "ext-mbstring": "*",
                 "fig/http-message-util": "^1.1.5",
-                "firebase/php-jwt": "^6.10.2",
+                "firebase/php-jwt": "^6.10.2 || ^7.0.2",
                 "google/auth": "^1.45",
                 "google/cloud-storage": "^1.48.7",
                 "guzzlehttp/guzzle": "^7.9.2",
@@ -2027,7 +2073,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-27T22:03:59+00:00"
+            "time": "2026-02-18T23:43:18+00:00"
         },
         {
             "name": "kreait/firebase-tokens",
@@ -2184,16 +2230,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v12.51.0",
+            "version": "v12.61.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "ce4de3feb211e47c4f959d309ccf8a2733b1bc16"
+                "reference": "1124062a1ca92d290c8bcb9b7f649920fa6816bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/ce4de3feb211e47c4f959d309ccf8a2733b1bc16",
-                "reference": "ce4de3feb211e47c4f959d309ccf8a2733b1bc16",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/1124062a1ca92d290c8bcb9b7f649920fa6816bf",
+                "reference": "1124062a1ca92d290c8bcb9b7f649920fa6816bf",
                 "shasum": ""
             },
             "require": {
@@ -2214,7 +2260,7 @@
                 "guzzlehttp/uri-template": "^1.0",
                 "laravel/prompts": "^0.3.0",
                 "laravel/serializable-closure": "^1.3|^2.0",
-                "league/commonmark": "^2.7",
+                "league/commonmark": "^2.8.1",
                 "league/flysystem": "^3.25.1",
                 "league/flysystem-local": "^3.25.1",
                 "league/uri": "^7.5.1",
@@ -2234,8 +2280,8 @@
                 "symfony/mailer": "^7.2.0",
                 "symfony/mime": "^7.2.0",
                 "symfony/polyfill-php83": "^1.33",
-                "symfony/polyfill-php84": "^1.33",
-                "symfony/polyfill-php85": "^1.33",
+                "symfony/polyfill-php84": "^1.34",
+                "symfony/polyfill-php85": "^1.34",
                 "symfony/process": "^7.2.0",
                 "symfony/routing": "^7.2.0",
                 "symfony/uid": "^7.2.0",
@@ -2309,7 +2355,7 @@
                 "orchestra/testbench-core": "^10.9.0",
                 "pda/pheanstalk": "^5.0.6|^7.0.0",
                 "php-http/discovery": "^1.15",
-                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan": "^2.1.41",
                 "phpunit/phpunit": "^10.5.35|^11.5.3|^12.0.1",
                 "predis/predis": "^2.3|^3.0",
                 "resend/resend-php": "^0.10.0|^1.0",
@@ -2402,20 +2448,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-02-10T18:20:19+00:00"
+            "time": "2026-05-26T23:41:33+00:00"
         },
         {
             "name": "laravel/prompts",
-            "version": "v0.3.13",
+            "version": "v0.3.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "ed8c466571b37e977532fb2fd3c272c784d7050d"
+                "reference": "a19af51bb144bf87f08397921fa619f85c7d4e72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/ed8c466571b37e977532fb2fd3c272c784d7050d",
-                "reference": "ed8c466571b37e977532fb2fd3c272c784d7050d",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/a19af51bb144bf87f08397921fa619f85c7d4e72",
+                "reference": "a19af51bb144bf87f08397921fa619f85c7d4e72",
                 "shasum": ""
             },
             "require": {
@@ -2459,22 +2505,22 @@
             "description": "Add beautiful and user-friendly forms to your command-line applications.",
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/v0.3.13"
+                "source": "https://github.com/laravel/prompts/tree/v0.3.18"
             },
-            "time": "2026-02-06T12:17:10+00:00"
+            "time": "2026-05-19T00:47:18+00:00"
         },
         {
             "name": "laravel/sanctum",
-            "version": "v4.3.1",
+            "version": "v4.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/sanctum.git",
-                "reference": "e3b85d6e36ad00e5db2d1dcc27c81ffdf15cbf76"
+                "reference": "2a9bccc18e9907808e0018dd15fa643937886b1e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/sanctum/zipball/e3b85d6e36ad00e5db2d1dcc27c81ffdf15cbf76",
-                "reference": "e3b85d6e36ad00e5db2d1dcc27c81ffdf15cbf76",
+                "url": "https://api.github.com/repos/laravel/sanctum/zipball/2a9bccc18e9907808e0018dd15fa643937886b1e",
+                "reference": "2a9bccc18e9907808e0018dd15fa643937886b1e",
                 "shasum": ""
             },
             "require": {
@@ -2524,20 +2570,20 @@
                 "issues": "https://github.com/laravel/sanctum/issues",
                 "source": "https://github.com/laravel/sanctum"
             },
-            "time": "2026-02-07T17:19:31+00:00"
+            "time": "2026-04-30T11:46:25+00:00"
         },
         {
             "name": "laravel/serializable-closure",
-            "version": "v2.0.9",
+            "version": "v2.0.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/serializable-closure.git",
-                "reference": "8f631589ab07b7b52fead814965f5a800459cb3e"
+                "reference": "b566ee0dd251f3c4078bed003a7ce015f5ea6dce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/8f631589ab07b7b52fead814965f5a800459cb3e",
-                "reference": "8f631589ab07b7b52fead814965f5a800459cb3e",
+                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/b566ee0dd251f3c4078bed003a7ce015f5ea6dce",
+                "reference": "b566ee0dd251f3c4078bed003a7ce015f5ea6dce",
                 "shasum": ""
             },
             "require": {
@@ -2585,36 +2631,36 @@
                 "issues": "https://github.com/laravel/serializable-closure/issues",
                 "source": "https://github.com/laravel/serializable-closure"
             },
-            "time": "2026-02-03T06:55:34+00:00"
+            "time": "2026-04-16T14:03:50+00:00"
         },
         {
             "name": "laravel/socialite",
-            "version": "v5.24.2",
+            "version": "v5.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/socialite.git",
-                "reference": "5cea2eebf11ca4bc6c2f20495c82a70a9b3d1613"
+                "reference": "40e0757a75637c7b2dff05d3286b0d8fc25e5c0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/socialite/zipball/5cea2eebf11ca4bc6c2f20495c82a70a9b3d1613",
-                "reference": "5cea2eebf11ca4bc6c2f20495c82a70a9b3d1613",
+                "url": "https://api.github.com/repos/laravel/socialite/zipball/40e0757a75637c7b2dff05d3286b0d8fc25e5c0e",
+                "reference": "40e0757a75637c7b2dff05d3286b0d8fc25e5c0e",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "firebase/php-jwt": "^6.4|^7.0",
                 "guzzlehttp/guzzle": "^6.0|^7.0",
-                "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-                "illuminate/http": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-                "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+                "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/http": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
                 "league/oauth1-client": "^1.11",
                 "php": "^7.2|^8.0",
                 "phpseclib/phpseclib": "^3.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.0",
-                "orchestra/testbench": "^4.18|^5.20|^6.47|^7.55|^8.36|^9.15|^10.8",
+                "orchestra/testbench": "^4.18|^5.20|^6.47|^7.55|^8.36|^9.15|^10.8|^11.0",
                 "phpstan/phpstan": "^1.12.23",
                 "phpunit/phpunit": "^8.0|^9.3|^10.4|^11.5|^12.0"
             },
@@ -2657,7 +2703,7 @@
                 "issues": "https://github.com/laravel/socialite/issues",
                 "source": "https://github.com/laravel/socialite"
             },
-            "time": "2026-01-10T16:07:28+00:00"
+            "time": "2026-04-24T14:05:47+00:00"
         },
         {
             "name": "lcobucci/clock",
@@ -2798,16 +2844,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.0",
+            "version": "2.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "4efa10c1e56488e658d10adf7b7b7dcd19940bfb"
+                "reference": "59fb075d2101740c337c7216e3f32b36c204218b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/4efa10c1e56488e658d10adf7b7b7dcd19940bfb",
-                "reference": "4efa10c1e56488e658d10adf7b7b7dcd19940bfb",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/59fb075d2101740c337c7216e3f32b36c204218b",
+                "reference": "59fb075d2101740c337c7216e3f32b36c204218b",
                 "shasum": ""
             },
             "require": {
@@ -2832,9 +2878,9 @@
                 "phpstan/phpstan": "^1.8.2",
                 "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
                 "scrutinizer/ocular": "^1.8.1",
-                "symfony/finder": "^5.3 | ^6.0 | ^7.0",
-                "symfony/process": "^5.4 | ^6.0 | ^7.0",
-                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0",
+                "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0 || ^8.0",
                 "unleashedtech/php-coding-standard": "^3.1.1",
                 "vimeo/psalm": "^4.24.0 || ^5.0.0 || ^6.0.0"
             },
@@ -2901,7 +2947,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-26T21:48:24+00:00"
+            "time": "2026-03-19T13:16:38+00:00"
         },
         {
             "name": "league/config",
@@ -2987,16 +3033,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "3.31.0",
+            "version": "3.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "1717e0b3642b0df65ecb0cc89cdd99fa840672ff"
+                "reference": "2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/1717e0b3642b0df65ecb0cc89cdd99fa840672ff",
-                "reference": "1717e0b3642b0df65ecb0cc89cdd99fa840672ff",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e",
+                "reference": "2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e",
                 "shasum": ""
             },
             "require": {
@@ -3064,9 +3110,9 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.31.0"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.34.0"
             },
-            "time": "2026-01-23T15:38:47+00:00"
+            "time": "2026-05-14T10:28:08+00:00"
         },
         {
             "name": "league/flysystem-local",
@@ -3251,20 +3297,20 @@
         },
         {
             "name": "league/uri",
-            "version": "7.8.0",
+            "version": "7.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri.git",
-                "reference": "4436c6ec8d458e4244448b069cc572d088230b76"
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/4436c6ec8d458e4244448b069cc572d088230b76",
-                "reference": "4436c6ec8d458e4244448b069cc572d088230b76",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/08cf38e3924d4f56238125547b5720496fac8fd4",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4",
                 "shasum": ""
             },
             "require": {
-                "league/uri-interfaces": "^7.8",
+                "league/uri-interfaces": "^7.8.1",
                 "php": "^8.1",
                 "psr/http-factory": "^1"
             },
@@ -3337,7 +3383,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri/tree/7.8.0"
+                "source": "https://github.com/thephpleague/uri/tree/7.8.1"
             },
             "funding": [
                 {
@@ -3345,20 +3391,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-14T17:24:56+00:00"
+            "time": "2026-03-15T20:22:25+00:00"
         },
         {
             "name": "league/uri-interfaces",
-            "version": "7.8.0",
+            "version": "7.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri-interfaces.git",
-                "reference": "c5c5cd056110fc8afaba29fa6b72a43ced42acd4"
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/c5c5cd056110fc8afaba29fa6b72a43ced42acd4",
-                "reference": "c5c5cd056110fc8afaba29fa6b72a43ced42acd4",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928",
                 "shasum": ""
             },
             "require": {
@@ -3421,7 +3467,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.0"
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.1"
             },
             "funding": [
                 {
@@ -3429,7 +3475,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-15T06:54:53+00:00"
+            "time": "2026-03-08T20:05:35+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -3602,16 +3648,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "3.11.1",
+            "version": "3.11.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "f438fcc98f92babee98381d399c65336f3a3827f"
+                "reference": "e890471a3494740f7d9326d72ce6a8c559ffee60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/f438fcc98f92babee98381d399c65336f3a3827f",
-                "reference": "f438fcc98f92babee98381d399c65336f3a3827f",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/e890471a3494740f7d9326d72ce6a8c559ffee60",
+                "reference": "e890471a3494740f7d9326d72ce6a8c559ffee60",
                 "shasum": ""
             },
             "require": {
@@ -3703,20 +3749,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-29T09:26:29+00:00"
+            "time": "2026-04-07T09:57:54+00:00"
         },
         {
             "name": "nette/schema",
-            "version": "v1.3.4",
+            "version": "v1.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/schema.git",
-                "reference": "086497a2f34b82fede9b5a41cc8e131d087cd8f7"
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/schema/zipball/086497a2f34b82fede9b5a41cc8e131d087cd8f7",
-                "reference": "086497a2f34b82fede9b5a41cc8e131d087cd8f7",
+                "url": "https://api.github.com/repos/nette/schema/zipball/f0ab1a3cda782dbc5da270d28545236aa80c4002",
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002",
                 "shasum": ""
             },
             "require": {
@@ -3724,8 +3770,10 @@
                 "php": "8.1 - 8.5"
             },
             "require-dev": {
+                "nette/phpstan-rules": "^1.0",
                 "nette/tester": "^2.6",
-                "phpstan/phpstan": "^2.0@stable",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1.39@stable",
                 "tracy/tracy": "^2.8"
             },
             "type": "library",
@@ -3766,22 +3814,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/schema/issues",
-                "source": "https://github.com/nette/schema/tree/v1.3.4"
+                "source": "https://github.com/nette/schema/tree/v1.3.5"
             },
-            "time": "2026-02-08T02:54:00+00:00"
+            "time": "2026-02-23T03:47:12+00:00"
         },
         {
             "name": "nette/utils",
-            "version": "v4.1.3",
+            "version": "v4.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe"
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/bb3ea637e3d131d72acc033cfc2746ee893349fe",
-                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe",
+                "url": "https://api.github.com/repos/nette/utils/zipball/7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
                 "shasum": ""
             },
             "require": {
@@ -3857,37 +3905,37 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.1.3"
+                "source": "https://github.com/nette/utils/tree/v4.1.4"
             },
-            "time": "2026-02-13T03:05:33+00:00"
+            "time": "2026-05-11T20:49:54+00:00"
         },
         {
             "name": "nunomaduro/termwind",
-            "version": "v2.3.3",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/termwind.git",
-                "reference": "6fb2a640ff502caace8e05fd7be3b503a7e1c017"
+                "reference": "712a31b768f5daea284c2169a7d227031001b9a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/6fb2a640ff502caace8e05fd7be3b503a7e1c017",
-                "reference": "6fb2a640ff502caace8e05fd7be3b503a7e1c017",
+                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/712a31b768f5daea284c2169a7d227031001b9a8",
+                "reference": "712a31b768f5daea284c2169a7d227031001b9a8",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "php": "^8.2",
-                "symfony/console": "^7.3.6"
+                "symfony/console": "^7.4.4 || ^8.0.4"
             },
             "require-dev": {
-                "illuminate/console": "^11.46.1",
-                "laravel/pint": "^1.25.1",
+                "illuminate/console": "^11.47.0",
+                "laravel/pint": "^1.27.1",
                 "mockery/mockery": "^1.6.12",
-                "pestphp/pest": "^2.36.0 || ^3.8.4 || ^4.1.3",
+                "pestphp/pest": "^2.36.0 || ^3.8.4 || ^4.3.2",
                 "phpstan/phpstan": "^1.12.32",
                 "phpstan/phpstan-strict-rules": "^1.6.2",
-                "symfony/var-dumper": "^7.3.5",
+                "symfony/var-dumper": "^7.3.5 || ^8.0.4",
                 "thecodingmachine/phpstan-strict-rules": "^1.0.0"
             },
             "type": "library",
@@ -3919,7 +3967,7 @@
                     "email": "enunomaduro@gmail.com"
                 }
             ],
-            "description": "Its like Tailwind CSS, but for the console.",
+            "description": "It's like Tailwind CSS, but for the console.",
             "keywords": [
                 "cli",
                 "console",
@@ -3930,7 +3978,7 @@
             ],
             "support": {
                 "issues": "https://github.com/nunomaduro/termwind/issues",
-                "source": "https://github.com/nunomaduro/termwind/tree/v2.3.3"
+                "source": "https://github.com/nunomaduro/termwind/tree/v2.4.0"
             },
             "funding": [
                 {
@@ -3946,7 +3994,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-20T02:34:59+00:00"
+            "time": "2026-02-16T23:10:27+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",
@@ -4068,6 +4116,182 @@
             "time": "2020-10-15T08:29:30+00:00"
         },
         {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.1",
+                "ext-filter": "*",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0",
+                "webmozart/assert": "^1.9.1 || ^2"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.5 || ~1.6.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-webmozart-assert": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^5.26",
+                "shipmonk/dead-code-detector": "^0.5.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.3"
+            },
+            "time": "2026-03-18T20:49:53+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev",
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/2.0.0"
+            },
+            "time": "2026-01-06T21:53:42+00:00"
+        },
+        {
             "name": "phpoption/phpoption",
             "version": "1.9.5",
             "source": {
@@ -4144,16 +4368,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.49",
+            "version": "3.0.52",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "6233a1e12584754e6b5daa69fe1289b47775c1b9"
+                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/6233a1e12584754e6b5daa69fe1289b47775c1b9",
-                "reference": "6233a1e12584754e6b5daa69fe1289b47775c1b9",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/2adaefc83df2ec548558307690f376dd7d4f4fce",
+                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce",
                 "shasum": ""
             },
             "require": {
@@ -4234,7 +4458,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.49"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.52"
             },
             "funding": [
                 {
@@ -4250,7 +4474,54 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-27T09:17:28+00:00"
+            "time": "2026-04-27T07:02:15+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
+            },
+            "time": "2026-01-25T14:56:51+00:00"
         },
         {
             "name": "psr/cache",
@@ -4913,16 +5184,16 @@
         },
         {
             "name": "rize/uri-template",
-            "version": "0.4.1",
+            "version": "0.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rize/UriTemplate.git",
-                "reference": "abb53c8b73a5b6c24e11f49036ab842f560cad33"
+                "reference": "7ad22944daede547b4542e1c977ec4a81aa20832"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rize/UriTemplate/zipball/abb53c8b73a5b6c24e11f49036ab842f560cad33",
-                "reference": "abb53c8b73a5b6c24e11f49036ab842f560cad33",
+                "url": "https://api.github.com/repos/rize/UriTemplate/zipball/7ad22944daede547b4542e1c977ec4a81aa20832",
+                "reference": "7ad22944daede547b4542e1c977ec4a81aa20832",
                 "shasum": ""
             },
             "require": {
@@ -4957,7 +5228,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rize/UriTemplate/issues",
-                "source": "https://github.com/rize/UriTemplate/tree/0.4.1"
+                "source": "https://github.com/rize/UriTemplate/tree/0.4.2"
             },
             "funding": [
                 {
@@ -4973,7 +5244,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2025-12-02T15:19:04+00:00"
+            "time": "2026-05-07T15:30:40+00:00"
         },
         {
             "name": "smartpings/php-sdk",
@@ -5032,22 +5303,21 @@
         },
         {
             "name": "socialiteproviders/apple",
-            "version": "5.8.0",
+            "version": "5.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/SocialiteProviders/Apple.git",
-                "reference": "3d9571ec667e2a8c912cff955510557e4e490635"
+                "reference": "11d871eb8193c31a2230fdf56929952eaf81fac2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SocialiteProviders/Apple/zipball/3d9571ec667e2a8c912cff955510557e4e490635",
-                "reference": "3d9571ec667e2a8c912cff955510557e4e490635",
+                "url": "https://api.github.com/repos/SocialiteProviders/Apple/zipball/11d871eb8193c31a2230fdf56929952eaf81fac2",
+                "reference": "11d871eb8193c31a2230fdf56929952eaf81fac2",
                 "shasum": ""
             },
             "require": {
-                "ext-json": "*",
                 "ext-openssl": "*",
-                "firebase/php-jwt": "^6.8 || ^7.0",
+                "firebase/php-jwt": "^7.0",
                 "lcobucci/clock": "^2.0 || ^3.0",
                 "lcobucci/jwt": "^4.1.5 || ^5.0.0",
                 "php": "^8.0",
@@ -5100,7 +5370,7 @@
                 "issues": "https://github.com/socialiteproviders/providers/issues",
                 "source": "https://github.com/socialiteproviders/providers"
             },
-            "time": "2026-02-03T16:07:42+00:00"
+            "time": "2026-03-22T23:23:52+00:00"
         },
         {
             "name": "socialiteproviders/manager",
@@ -5177,17 +5447,198 @@
             "time": "2026-03-18T22:13:24+00:00"
         },
         {
-            "name": "symfony/cache",
-            "version": "v7.4.5",
+            "name": "spomky-labs/cbor-php",
+            "version": "3.2.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/cache.git",
-                "reference": "8dde98d5a4123b53877aca493f9be57b333f14bd"
+                "url": "https://github.com/Spomky-Labs/cbor-php.git",
+                "reference": "dd6eb84e6d92f7b8bd0da56b4b4dd7235aed0c32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/8dde98d5a4123b53877aca493f9be57b333f14bd",
-                "reference": "8dde98d5a4123b53877aca493f9be57b333f14bd",
+                "url": "https://api.github.com/repos/Spomky-Labs/cbor-php/zipball/dd6eb84e6d92f7b8bd0da56b4b4dd7235aed0c32",
+                "reference": "dd6eb84e6d92f7b8bd0da56b4b4dd7235aed0c32",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.9|^0.10|^0.11|^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
+                "ext-mbstring": "*",
+                "php": ">=8.0"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "roave/security-advisories": "dev-latest",
+                "symfony/error-handler": "^6.4|^7.1|^8.0",
+                "symfony/var-dumper": "^6.4|^7.1|^8.0"
+            },
+            "suggest": {
+                "ext-bcmath": "GMP or BCMath extensions will drastically improve the library performance. BCMath extension needed to handle the Big Float and Decimal Fraction Tags",
+                "ext-gmp": "GMP or BCMath extensions will drastically improve the library performance"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "CBOR\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/Spomky-Labs/cbor-php/contributors"
+                }
+            ],
+            "description": "CBOR Encoder/Decoder for PHP",
+            "keywords": [
+                "Concise Binary Object Representation",
+                "RFC7049",
+                "cbor"
+            ],
+            "support": {
+                "issues": "https://github.com/Spomky-Labs/cbor-php/issues",
+                "source": "https://github.com/Spomky-Labs/cbor-php/tree/3.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-04-01T12:15:20+00:00"
+        },
+        {
+            "name": "spomky-labs/pki-framework",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Spomky-Labs/pki-framework.git",
+                "reference": "aa576cbd07128075bef97ac2f8af9854e67513d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Spomky-Labs/pki-framework/zipball/aa576cbd07128075bef97ac2f8af9854e67513d8",
+                "reference": "aa576cbd07128075bef97ac2f8af9854e67513d8",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.10|^0.11|^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "psr/clock": "^1.0"
+            },
+            "require-dev": {
+                "ekino/phpstan-banned-code": "^1.0|^2.0|^3.0",
+                "ext-gmp": "*",
+                "ext-openssl": "*",
+                "infection/infection": "^0.28|^0.29|^0.31|^0.32",
+                "php-parallel-lint/php-parallel-lint": "^1.3",
+                "phpstan/extension-installer": "^1.3|^2.0",
+                "phpstan/phpstan": "^1.8|^2.0",
+                "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
+                "phpstan/phpstan-phpunit": "^1.1|^2.0",
+                "phpstan/phpstan-strict-rules": "^1.3|^2.0",
+                "phpunit/phpunit": "^10.1|^11.0|^12.0|^13.0",
+                "rector/rector": "^1.0|^2.0",
+                "roave/security-advisories": "dev-latest",
+                "symfony/string": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0",
+                "symplify/easy-coding-standard": "^12.0|^13.0"
+            },
+            "suggest": {
+                "ext-bcmath": "For better performance (or GMP)",
+                "ext-gmp": "For better performance (or BCMath)",
+                "ext-openssl": "For OpenSSL based cyphering"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "SpomkyLabs\\Pki\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Joni Eskelinen",
+                    "email": "jonieske@gmail.com",
+                    "role": "Original developer"
+                },
+                {
+                    "name": "Florent Morselli",
+                    "email": "florent.morselli@spomky-labs.com",
+                    "role": "Spomky-Labs PKI Framework developer"
+                }
+            ],
+            "description": "A PHP framework for managing Public Key Infrastructures. It comprises X.509 public key certificates, attribute certificates, certification requests and certification path validation.",
+            "homepage": "https://github.com/spomky-labs/pki-framework",
+            "keywords": [
+                "DER",
+                "Private Key",
+                "ac",
+                "algorithm identifier",
+                "asn.1",
+                "asn1",
+                "attribute certificate",
+                "certificate",
+                "certification request",
+                "cryptography",
+                "csr",
+                "decrypt",
+                "ec",
+                "encrypt",
+                "pem",
+                "pkcs",
+                "public key",
+                "rsa",
+                "sign",
+                "signature",
+                "verify",
+                "x.509",
+                "x.690",
+                "x509",
+                "x690"
+            ],
+            "support": {
+                "issues": "https://github.com/Spomky-Labs/pki-framework/issues",
+                "source": "https://github.com/Spomky-Labs/pki-framework/tree/1.4.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-03-23T22:56:56+00:00"
+        },
+        {
+            "name": "symfony/cache",
+            "version": "v7.4.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache.git",
+                "reference": "4c09e18a92cce126cc0d1155825279fca8cd0673"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/4c09e18a92cce126cc0d1155825279fca8cd0673",
+                "reference": "4c09e18a92cce126cc0d1155825279fca8cd0673",
                 "shasum": ""
             },
             "require": {
@@ -5258,7 +5709,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v7.4.5"
+                "source": "https://github.com/symfony/cache/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -5278,20 +5729,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-27T16:16:02+00:00"
+            "time": "2026-05-24T08:43:14+00:00"
         },
         {
             "name": "symfony/cache-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache-contracts.git",
-                "reference": "5d68a57d66910405e5c0b63d6f0af941e66fc868"
+                "reference": "225e8a254166bd3442e370c6f50145465db63831"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/5d68a57d66910405e5c0b63d6f0af941e66fc868",
-                "reference": "5d68a57d66910405e5c0b63d6f0af941e66fc868",
+                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/225e8a254166bd3442e370c6f50145465db63831",
+                "reference": "225e8a254166bd3442e370c6f50145465db63831",
                 "shasum": ""
             },
             "require": {
@@ -5305,7 +5756,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -5338,7 +5789,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/cache-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -5350,24 +5801,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-13T15:25:07+00:00"
+            "time": "2026-05-05T15:33:14+00:00"
         },
         {
             "name": "symfony/clock",
-            "version": "v7.4.0",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/clock.git",
-                "reference": "9169f24776edde469914c1e7a1442a50f7a4e110"
+                "reference": "674fa3b98e21531dd040e613479f5f6fa8f32111"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/clock/zipball/9169f24776edde469914c1e7a1442a50f7a4e110",
-                "reference": "9169f24776edde469914c1e7a1442a50f7a4e110",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/674fa3b98e21531dd040e613479f5f6fa8f32111",
+                "reference": "674fa3b98e21531dd040e613479f5f6fa8f32111",
                 "shasum": ""
             },
             "require": {
@@ -5412,7 +5867,7 @@
                 "time"
             ],
             "support": {
-                "source": "https://github.com/symfony/clock/tree/v7.4.0"
+                "source": "https://github.com/symfony/clock/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -5432,20 +5887,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-12T15:39:26+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.4",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "41e38717ac1dd7a46b6bda7d6a82af2d98a78894"
+                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/41e38717ac1dd7a46b6bda7d6a82af2d98a78894",
-                "reference": "41e38717ac1dd7a46b6bda7d6a82af2d98a78894",
+                "url": "https://api.github.com/repos/symfony/console/zipball/85095d2573eaefaf35e40b9513a9bf09f72cd217",
+                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217",
                 "shasum": ""
             },
             "require": {
@@ -5510,7 +5965,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.4"
+                "source": "https://github.com/symfony/console/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -5530,20 +5985,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-13T11:36:38+00:00"
+            "time": "2026-05-24T08:56:14+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v7.4.0",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "ab862f478513e7ca2fe9ec117a6f01a8da6e1135"
+                "reference": "b75663ed96cf4756e28e3105476f220f92886cc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/ab862f478513e7ca2fe9ec117a6f01a8da6e1135",
-                "reference": "ab862f478513e7ca2fe9ec117a6f01a8da6e1135",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/b75663ed96cf4756e28e3105476f220f92886cc4",
+                "reference": "b75663ed96cf4756e28e3105476f220f92886cc4",
                 "shasum": ""
             },
             "require": {
@@ -5579,7 +6034,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v7.4.0"
+                "source": "https://github.com/symfony/css-selector/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -5599,20 +6054,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-30T13:39:42+00:00"
+            "time": "2026-04-18T13:18:21+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
@@ -5625,7 +6080,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -5650,7 +6105,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -5662,24 +6117,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         },
         {
             "name": "symfony/error-handler",
-            "version": "v7.4.4",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "8da531f364ddfee53e36092a7eebbbd0b775f6b8"
+                "reference": "8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/8da531f364ddfee53e36092a7eebbbd0b775f6b8",
-                "reference": "8da531f364ddfee53e36092a7eebbbd0b775f6b8",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa",
+                "reference": "8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa",
                 "shasum": ""
             },
             "require": {
@@ -5728,7 +6187,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v7.4.4"
+                "source": "https://github.com/symfony/error-handler/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -5748,20 +6207,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-20T16:42:42+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.4.4",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "dc2c0eba1af673e736bb851d747d266108aea746"
+                "reference": "e4a2e29753c7801f7a8340e066cfa788f3bc8101"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/dc2c0eba1af673e736bb851d747d266108aea746",
-                "reference": "dc2c0eba1af673e736bb851d747d266108aea746",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/e4a2e29753c7801f7a8340e066cfa788f3bc8101",
+                "reference": "e4a2e29753c7801f7a8340e066cfa788f3bc8101",
                 "shasum": ""
             },
             "require": {
@@ -5813,7 +6272,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.4"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -5833,20 +6292,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T11:45:34+00:00"
+            "time": "2026-04-18T13:18:21+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586"
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/59eb412e93815df44f05f342958efa9f46b1e586",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/ccba7060602b7fed0b03c85bf025257f76d9ef32",
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32",
                 "shasum": ""
             },
             "require": {
@@ -5860,7 +6319,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -5893,7 +6352,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -5905,24 +6364,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-01-05T13:30:16+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v7.4.5",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "ad4daa7c38668dcb031e63bc99ea9bd42196a2cb"
+                "reference": "e0be088d22278583a82da281886e8c3592fbf149"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/ad4daa7c38668dcb031e63bc99ea9bd42196a2cb",
-                "reference": "ad4daa7c38668dcb031e63bc99ea9bd42196a2cb",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/e0be088d22278583a82da281886e8c3592fbf149",
+                "reference": "e0be088d22278583a82da281886e8c3592fbf149",
                 "shasum": ""
             },
             "require": {
@@ -5957,7 +6420,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.4.5"
+                "source": "https://github.com/symfony/finder/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -5977,20 +6440,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-26T15:07:59+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.4.5",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "446d0db2b1f21575f1284b74533e425096abdfb6"
+                "reference": "bc354f47c62301e990b7874fa662326368508e2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/446d0db2b1f21575f1284b74533e425096abdfb6",
-                "reference": "446d0db2b1f21575f1284b74533e425096abdfb6",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/bc354f47c62301e990b7874fa662326368508e2c",
+                "reference": "bc354f47c62301e990b7874fa662326368508e2c",
                 "shasum": ""
             },
             "require": {
@@ -6039,7 +6502,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.4.5"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -6059,20 +6522,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-27T16:16:02+00:00"
+            "time": "2026-05-24T11:20:33+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.4.5",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "229eda477017f92bd2ce7615d06222ec0c19e82a"
+                "reference": "9df847980c436451f4f51d1284491bb4356dd989"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/229eda477017f92bd2ce7615d06222ec0c19e82a",
-                "reference": "229eda477017f92bd2ce7615d06222ec0c19e82a",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/9df847980c436451f4f51d1284491bb4356dd989",
+                "reference": "9df847980c436451f4f51d1284491bb4356dd989",
                 "shasum": ""
             },
             "require": {
@@ -6114,7 +6577,7 @@
                 "symfony/config": "^6.4|^7.0|^8.0",
                 "symfony/console": "^6.4|^7.0|^8.0",
                 "symfony/css-selector": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4.1|^7.0.1|^8.0",
                 "symfony/dom-crawler": "^6.4|^7.0|^8.0",
                 "symfony/expression-language": "^6.4|^7.0|^8.0",
                 "symfony/finder": "^6.4|^7.0|^8.0",
@@ -6158,7 +6621,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.4.5"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -6178,20 +6641,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-28T10:33:42+00:00"
+            "time": "2026-05-27T08:31:43+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.4.4",
+            "version": "v7.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "7b750074c40c694ceb34cb926d6dffee231c5cd6"
+                "reference": "5cefb712a25f320579615ba9e1942abaeade7dff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/7b750074c40c694ceb34cb926d6dffee231c5cd6",
-                "reference": "7b750074c40c694ceb34cb926d6dffee231c5cd6",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/5cefb712a25f320579615ba9e1942abaeade7dff",
+                "reference": "5cefb712a25f320579615ba9e1942abaeade7dff",
                 "shasum": ""
             },
             "require": {
@@ -6242,7 +6705,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.4.4"
+                "source": "https://github.com/symfony/mailer/tree/v7.4.12"
             },
             "funding": [
                 {
@@ -6262,20 +6725,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-08T08:25:11+00:00"
+            "time": "2026-05-20T07:20:23+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v7.4.5",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "b18c7e6e9eee1e19958138df10412f3c4c316148"
+                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/b18c7e6e9eee1e19958138df10412f3c4c316148",
-                "reference": "b18c7e6e9eee1e19958138df10412f3c4c316148",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/a845722765c4f6b2ce88beaf4f4479975b186770",
+                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770",
                 "shasum": ""
             },
             "require": {
@@ -6286,7 +6749,7 @@
             },
             "conflict": {
                 "egulias/email-validator": "~3.0.0",
-                "phpdocumentor/reflection-docblock": "<5.2|>=6",
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
                 "phpdocumentor/type-resolver": "<1.5.1",
                 "symfony/mailer": "<6.4",
                 "symfony/serializer": "<6.4.3|>7.0,<7.0.3"
@@ -6294,7 +6757,7 @@
             "require-dev": {
                 "egulias/email-validator": "^2.1.10|^3.1|^4",
                 "league/html-to-markdown": "^5.0",
-                "phpdocumentor/reflection-docblock": "^5.2",
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
                 "symfony/dependency-injection": "^6.4|^7.0|^8.0",
                 "symfony/process": "^6.4|^7.0|^8.0",
                 "symfony/property-access": "^6.4|^7.0|^8.0",
@@ -6331,7 +6794,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v7.4.5"
+                "source": "https://github.com/symfony/mime/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -6351,20 +6814,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-27T08:59:58+00:00"
+            "time": "2026-05-23T16:22:37+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -6414,7 +6877,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -6434,20 +6897,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70"
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
                 "shasum": ""
             },
             "require": {
@@ -6496,7 +6959,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -6516,20 +6979,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T09:58:17+00:00"
+            "time": "2026-05-26T05:58:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3"
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/9614ac4d8061dc257ecc64cba1b140873dce8ad3",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
                 "shasum": ""
             },
             "require": {
@@ -6583,7 +7046,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -6603,20 +7066,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-10T14:38:51+00:00"
+            "time": "2026-05-25T15:22:23+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.33.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
                 "shasum": ""
             },
             "require": {
@@ -6668,7 +7131,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -6688,20 +7151,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-25T13:48:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
                 "shasum": ""
             },
             "require": {
@@ -6753,7 +7216,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -6773,20 +7236,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
                 "shasum": ""
             },
             "require": {
@@ -6837,7 +7300,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -6857,20 +7320,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-02T08:10:11+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5"
+                "reference": "8339098cae28673c15cce00d80734af0453054e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/17f6f9a6b1735c0f163024d959f700cfbc5155e5",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/8339098cae28673c15cce00d80734af0453054e2",
+                "reference": "8339098cae28673c15cce00d80734af0453054e2",
                 "shasum": ""
             },
             "require": {
@@ -6917,7 +7380,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -6937,20 +7400,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-08T02:45:35+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
-                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191"
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/d8ced4d875142b6a7426000426b8abc631d6b191",
-                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
                 "shasum": ""
             },
             "require": {
@@ -6997,7 +7460,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -7017,20 +7480,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-24T13:30:11+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php85",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php85.git",
-                "reference": "d4e5fcd4ab3d998ab16c0db48e6cbb9a01993f91"
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/d4e5fcd4ab3d998ab16c0db48e6cbb9a01993f91",
-                "reference": "d4e5fcd4ab3d998ab16c0db48e6cbb9a01993f91",
+                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
                 "shasum": ""
             },
             "require": {
@@ -7077,7 +7540,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php85/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php85/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -7097,20 +7560,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-23T16:12:55+00:00"
+            "time": "2026-05-26T02:25:22+00:00"
         },
         {
             "name": "symfony/polyfill-uuid",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-uuid.git",
-                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2"
+                "reference": "26dfec253c4cf3e51b541b52ddf7e42cb0908e94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
-                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
+                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/26dfec253c4cf3e51b541b52ddf7e42cb0908e94",
+                "reference": "26dfec253c4cf3e51b541b52ddf7e42cb0908e94",
                 "shasum": ""
             },
             "require": {
@@ -7160,7 +7623,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -7180,20 +7643,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v7.4.5",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "608476f4604102976d687c483ac63a79ba18cc97"
+                "reference": "f5804be144caceb570f6747519999636b664f24c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/608476f4604102976d687c483ac63a79ba18cc97",
-                "reference": "608476f4604102976d687c483ac63a79ba18cc97",
+                "url": "https://api.github.com/repos/symfony/process/zipball/f5804be144caceb570f6747519999636b664f24c",
+                "reference": "f5804be144caceb570f6747519999636b664f24c",
                 "shasum": ""
             },
             "require": {
@@ -7225,7 +7688,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.5"
+                "source": "https://github.com/symfony/process/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -7245,20 +7708,191 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-26T15:07:59+00:00"
+            "time": "2026-05-23T16:05:06+00:00"
         },
         {
-            "name": "symfony/routing",
-            "version": "v7.4.4",
+            "name": "symfony/property-access",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/routing.git",
-                "reference": "0798827fe2c79caeed41d70b680c2c3507d10147"
+                "url": "https://github.com/symfony/property-access.git",
+                "reference": "b7dad9dae8b8a47ef7ecc76c8569e7d8c7d90cfc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/0798827fe2c79caeed41d70b680c2c3507d10147",
-                "reference": "0798827fe2c79caeed41d70b680c2c3507d10147",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/b7dad9dae8b8a47ef7ecc76c8569e7d8c7d90cfc",
+                "reference": "b7dad9dae8b8a47ef7ecc76c8569e7d8c7d90cfc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/property-info": "^6.4.32|~7.3.10|^7.4.4|^8.0.4"
+            },
+            "require-dev": {
+                "symfony/cache": "^6.4|^7.0|^8.0",
+                "symfony/var-exporter": "^6.4.1|^7.0.1|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyAccess\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides functions to read and write from/to an object or array using a simple string notation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "access",
+                "array",
+                "extraction",
+                "index",
+                "injection",
+                "object",
+                "property",
+                "property-path",
+                "reflection"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/property-access/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
+            "name": "symfony/property-info",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/property-info.git",
+                "reference": "ac5e82528b986c4f7cfccbf7764b5d2e824d6175"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/ac5e82528b986c4f7cfccbf7764b5d2e824d6175",
+                "reference": "ac5e82528b986c4f7cfccbf7764b5d2e824d6175",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/string": "^6.4|^7.0|^8.0",
+                "symfony/type-info": "^7.4.7|^8.0.7"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1",
+                "symfony/cache": "<6.4",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/serializer": "<6.4"
+            },
+            "require-dev": {
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
+                "phpstan/phpdoc-parser": "^1.0|^2.0",
+                "symfony/cache": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyInfo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kévin Dunglas",
+                    "email": "dunglas@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Extracts information about PHP class' properties using metadata of popular sources",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "doctrine",
+                "phpdoc",
+                "property",
+                "symfony",
+                "type",
+                "validator"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/property-info/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
+            "name": "symfony/routing",
+            "version": "v7.4.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/routing.git",
+                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/3a162171bb008e5e0f15dce6581373a4c0e8390d",
+                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d",
                 "shasum": ""
             },
             "require": {
@@ -7310,7 +7944,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v7.4.4"
+                "source": "https://github.com/symfony/routing/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -7330,20 +7964,124 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-12T12:19:02+00:00"
+            "time": "2026-05-24T11:20:33+00:00"
         },
         {
-            "name": "symfony/service-contracts",
-            "version": "v3.6.1",
+            "name": "symfony/serializer",
+            "version": "v7.4.10",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+                "url": "https://github.com/symfony/serializer.git",
+                "reference": "268c5aa6c4bd675eddd89348e7ecac292a843ddd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/268c5aa6c4bd675eddd89348e7ecac292a843ddd",
+                "reference": "268c5aa6c4bd675eddd89348e7ecac292a843ddd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-php84": "^1.30"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/property-access": "<6.4.31|>=7.0,<7.4.2|>=8.0,<8.0.2",
+                "symfony/property-info": "<6.4",
+                "symfony/type-info": "<7.2.5",
+                "symfony/uid": "<6.4",
+                "symfony/validator": "<6.4",
+                "symfony/yaml": "<6.4"
+            },
+            "require-dev": {
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
+                "phpstan/phpdoc-parser": "^1.0|^2.0",
+                "seld/jsonlint": "^1.10",
+                "symfony/cache": "^6.4|^7.0|^8.0",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^7.2|^8.0",
+                "symfony/error-handler": "^6.4|^7.0|^8.0",
+                "symfony/filesystem": "^6.4|^7.0|^8.0",
+                "symfony/form": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/mime": "^6.4|^7.0|^8.0",
+                "symfony/property-access": "^6.4.31|^7.4.2|^8.0.2",
+                "symfony/property-info": "^6.4|^7.0|^8.0",
+                "symfony/translation-contracts": "^2.5|^3",
+                "symfony/type-info": "^7.2.5|^8.0",
+                "symfony/uid": "^6.4|^7.0|^8.0",
+                "symfony/validator": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0",
+                "symfony/var-exporter": "^6.4|^7.0|^8.0",
+                "symfony/yaml": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Serializer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/serializer/tree/v7.4.10"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-03T13:03:28+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
                 "shasum": ""
             },
             "require": {
@@ -7361,7 +8099,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -7397,7 +8135,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -7417,20 +8155,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T11:30:57+00:00"
+            "time": "2026-03-28T09:44:51+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v7.4.4",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "1c4b10461bf2ec27537b5f36105337262f5f5d6f"
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/1c4b10461bf2ec27537b5f36105337262f5f5d6f",
-                "reference": "1c4b10461bf2ec27537b5f36105337262f5f5d6f",
+                "url": "https://api.github.com/repos/symfony/string/zipball/961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
                 "shasum": ""
             },
             "require": {
@@ -7488,7 +8226,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.4.4"
+                "source": "https://github.com/symfony/string/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -7508,20 +8246,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-12T10:54:30+00:00"
+            "time": "2026-05-23T15:23:29+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v7.4.4",
+            "version": "v7.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "bfde13711f53f549e73b06d27b35a55207528877"
+                "reference": "ada7578c30dd5feaa8259cff3e885069ea81ddde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/bfde13711f53f549e73b06d27b35a55207528877",
-                "reference": "bfde13711f53f549e73b06d27b35a55207528877",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/ada7578c30dd5feaa8259cff3e885069ea81ddde",
+                "reference": "ada7578c30dd5feaa8259cff3e885069ea81ddde",
                 "shasum": ""
             },
             "require": {
@@ -7588,7 +8326,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v7.4.4"
+                "source": "https://github.com/symfony/translation/tree/v7.4.10"
             },
             "funding": [
                 {
@@ -7608,20 +8346,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-13T10:40:19+00:00"
+            "time": "2026-05-06T11:19:24+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "65a8bc82080447fae78373aa10f8d13b38338977"
+                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/65a8bc82080447fae78373aa10f8d13b38338977",
-                "reference": "65a8bc82080447fae78373aa10f8d13b38338977",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/0ab302977a952b42fd51475c4ebac81f8da0a95d",
+                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d",
                 "shasum": ""
             },
             "require": {
@@ -7634,7 +8372,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -7670,7 +8408,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -7690,20 +8428,103 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T13:41:35+00:00"
+            "time": "2026-01-05T13:30:16+00:00"
         },
         {
-            "name": "symfony/uid",
-            "version": "v7.4.4",
+            "name": "symfony/type-info",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/uid.git",
-                "reference": "7719ce8aba76be93dfe249192f1fbfa52c588e36"
+                "url": "https://github.com/symfony/type-info.git",
+                "reference": "cafeedbf157b890e94ac5b83eaed85595106d5d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/uid/zipball/7719ce8aba76be93dfe249192f1fbfa52c588e36",
-                "reference": "7719ce8aba76be93dfe249192f1fbfa52c588e36",
+                "url": "https://api.github.com/repos/symfony/type-info/zipball/cafeedbf157b890e94ac5b83eaed85595106d5d6",
+                "reference": "cafeedbf157b890e94ac5b83eaed85595106d5d6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "phpstan/phpdoc-parser": "<1.30"
+            },
+            "require-dev": {
+                "phpstan/phpdoc-parser": "^1.30|^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\TypeInfo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mathias Arlaud",
+                    "email": "mathias.arlaud@gmail.com"
+                },
+                {
+                    "name": "Baptiste LEDUC",
+                    "email": "baptiste.leduc@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Extracts PHP types information.",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "PHPStan",
+                "phpdoc",
+                "symfony",
+                "type"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/type-info/tree/v7.4.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-22T15:21:55+00:00"
+        },
+        {
+            "name": "symfony/uid",
+            "version": "v7.4.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/uid.git",
+                "reference": "2676b524340abcfe4d6151ec698463cebafee439"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/uid/zipball/2676b524340abcfe4d6151ec698463cebafee439",
+                "reference": "2676b524340abcfe4d6151ec698463cebafee439",
                 "shasum": ""
             },
             "require": {
@@ -7748,7 +8569,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/uid/tree/v7.4.4"
+                "source": "https://github.com/symfony/uid/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -7768,20 +8589,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-03T23:30:35+00:00"
+            "time": "2026-04-30T15:19:22+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.4.4",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "0e4769b46a0c3c62390d124635ce59f66874b282"
+                "reference": "9510c3966f749a1d1ff0059e1eabef6cc621e7fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/0e4769b46a0c3c62390d124635ce59f66874b282",
-                "reference": "0e4769b46a0c3c62390d124635ce59f66874b282",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/9510c3966f749a1d1ff0059e1eabef6cc621e7fd",
+                "reference": "9510c3966f749a1d1ff0059e1eabef6cc621e7fd",
                 "shasum": ""
             },
             "require": {
@@ -7835,7 +8656,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.4.4"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -7855,20 +8676,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-01T22:13:48+00:00"
+            "time": "2026-03-30T13:44:50+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v7.4.0",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "03a60f169c79a28513a78c967316fbc8bf17816f"
+                "reference": "22e03a49c95ef054a43601cd159b222bfab1c701"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/03a60f169c79a28513a78c967316fbc8bf17816f",
-                "reference": "03a60f169c79a28513a78c967316fbc8bf17816f",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/22e03a49c95ef054a43601cd159b222bfab1c701",
+                "reference": "22e03a49c95ef054a43601cd159b222bfab1c701",
                 "shasum": ""
             },
             "require": {
@@ -7916,7 +8737,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v7.4.0"
+                "source": "https://github.com/symfony/var-exporter/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -7936,7 +8757,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-11T10:15:23+00:00"
+            "time": "2026-04-18T13:18:21+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -8079,23 +8900,23 @@
         },
         {
             "name": "voku/portable-ascii",
-            "version": "2.0.3",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voku/portable-ascii.git",
-                "reference": "b1d923f88091c6bf09699efcd7c8a1b1bfd7351d"
+                "reference": "8e1051fe39379367aecf014f41744ce7539a856f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/b1d923f88091c6bf09699efcd7c8a1b1bfd7351d",
-                "reference": "b1d923f88091c6bf09699efcd7c8a1b1bfd7351d",
+                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/8e1051fe39379367aecf014f41744ce7539a856f",
+                "reference": "8e1051fe39379367aecf014f41744ce7539a856f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0.0"
+                "php": ">=7.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~6.0 || ~7.0 || ~9.0"
+                "phpunit/phpunit": "~8.5 || ~9.6 || ~10.5 || ~11.5"
             },
             "suggest": {
                 "ext-intl": "Use Intl for transliterator_transliterate() support"
@@ -8125,7 +8946,7 @@
             ],
             "support": {
                 "issues": "https://github.com/voku/portable-ascii/issues",
-                "source": "https://github.com/voku/portable-ascii/tree/2.0.3"
+                "source": "https://github.com/voku/portable-ascii/tree/2.1.1"
             },
             "funding": [
                 {
@@ -8149,7 +8970,230 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-21T01:49:47+00:00"
+            "time": "2026-04-26T05:33:54+00:00"
+        },
+        {
+            "name": "web-auth/cose-lib",
+            "version": "4.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/web-auth/cose-lib.git",
+                "reference": "5b38660f90070a8e45f3dbc9528ade3b608dd77d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/web-auth/cose-lib/zipball/5b38660f90070a8e45f3dbc9528ade3b608dd77d",
+                "reference": "5b38660f90070a8e45f3dbc9528ade3b608dd77d",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.9|^0.10|^0.11|^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "php": ">=8.1",
+                "spomky-labs/pki-framework": "^1.0"
+            },
+            "require-dev": {
+                "spomky-labs/cbor-php": "^3.2.2"
+            },
+            "suggest": {
+                "ext-bcmath": "For better performance, please install either GMP (recommended) or BCMath extension",
+                "ext-gmp": "For better performance, please install either GMP (recommended) or BCMath extension",
+                "spomky-labs/cbor-php": "For COSE Signature support"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cose\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/web-auth/cose/contributors"
+                }
+            ],
+            "description": "CBOR Object Signing and Encryption (COSE) For PHP",
+            "homepage": "https://github.com/web-auth",
+            "keywords": [
+                "COSE",
+                "RFC8152"
+            ],
+            "support": {
+                "issues": "https://github.com/web-auth/cose-lib/issues",
+                "source": "https://github.com/web-auth/cose-lib/tree/4.5.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-05-03T09:49:50+00:00"
+        },
+        {
+            "name": "web-auth/webauthn-lib",
+            "version": "5.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/web-auth/webauthn-lib.git",
+                "reference": "dbb2d7a03db5893da2ef1f2898063ab8f7792838"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/web-auth/webauthn-lib/zipball/dbb2d7a03db5893da2ef1f2898063ab8f7792838",
+                "reference": "dbb2d7a03db5893da2ef1f2898063ab8f7792838",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "paragonie/constant_time_encoding": "^2.6|^3.0",
+                "php": ">=8.2",
+                "phpdocumentor/reflection-docblock": "^5.3|^6.0",
+                "psr/clock": "^1.0",
+                "psr/event-dispatcher": "^1.0",
+                "psr/log": "^1.0|^2.0|^3.0",
+                "spomky-labs/cbor-php": "^3.0",
+                "spomky-labs/pki-framework": "^1.0",
+                "symfony/clock": "^6.4|^7.0|^8.0",
+                "symfony/deprecation-contracts": "^3.2",
+                "symfony/property-access": "^6.4|^7.0|^8.0",
+                "symfony/property-info": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4|^7.0|^8.0",
+                "symfony/uid": "^6.4|^7.0|^8.0",
+                "web-auth/cose-lib": "^4.2.3"
+            },
+            "suggest": {
+                "psr/log-implementation": "Recommended to receive logs from the library",
+                "symfony/event-dispatcher": "Recommended to use dispatched events",
+                "web-token/jwt-library": "Mandatory for fetching Metadata Statement from distant sources"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/web-auth/webauthn-framework",
+                    "name": "web-auth/webauthn-framework"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webauthn\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/web-auth/webauthn-library/contributors"
+                }
+            ],
+            "description": "FIDO2/Webauthn Support For PHP",
+            "homepage": "https://github.com/web-auth",
+            "keywords": [
+                "FIDO2",
+                "fido",
+                "webauthn"
+            ],
+            "support": {
+                "source": "https://github.com/web-auth/webauthn-lib/tree/5.3.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-05-18T11:59:46+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "9007ea6f45ecf352a9422b36644e4bfc039b9155"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9007ea6f45ecf352a9422b36644e4bfc039b9155",
+                "reference": "9007ea6f45ecf352a9422b36644e4bfc039b9155",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
+                "php": "^8.2"
+            },
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
+            },
+            "type": "library",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Webmozart\\Assert\\PsalmPlugin"
+                },
+                "branch-alias": {
+                    "dev-master": "2.0-dev",
+                    "dev-feature/2-0": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "email": "woody.gilk@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/2.4.0"
+            },
+            "time": "2026-05-20T13:07:01+00:00"
         }
     ],
     "packages-dev": [
@@ -8603,40 +9647,40 @@
         },
         {
             "name": "larastan/larastan",
-            "version": "v3.9.2",
+            "version": "v3.9.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/larastan/larastan.git",
-                "reference": "2e9ed291bdc1969e7f270fb33c9cdf3c912daeb2"
+                "reference": "9ad17e83e96b63536cb6ac39c3d40d29ff9cf636"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/larastan/larastan/zipball/2e9ed291bdc1969e7f270fb33c9cdf3c912daeb2",
-                "reference": "2e9ed291bdc1969e7f270fb33c9cdf3c912daeb2",
+                "url": "https://api.github.com/repos/larastan/larastan/zipball/9ad17e83e96b63536cb6ac39c3d40d29ff9cf636",
+                "reference": "9ad17e83e96b63536cb6ac39c3d40d29ff9cf636",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "iamcal/sql-parser": "^0.7.0",
-                "illuminate/console": "^11.44.2 || ^12.4.1",
-                "illuminate/container": "^11.44.2 || ^12.4.1",
-                "illuminate/contracts": "^11.44.2 || ^12.4.1",
-                "illuminate/database": "^11.44.2 || ^12.4.1",
-                "illuminate/http": "^11.44.2 || ^12.4.1",
-                "illuminate/pipeline": "^11.44.2 || ^12.4.1",
-                "illuminate/support": "^11.44.2 || ^12.4.1",
+                "illuminate/console": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/container": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/contracts": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/database": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/http": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/pipeline": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/support": "^11.44.2 || ^12.4.1 || ^13",
                 "php": "^8.2",
-                "phpstan/phpstan": "^2.1.32"
+                "phpstan/phpstan": "^2.1.44"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^13",
-                "laravel/framework": "^11.44.2 || ^12.7.2",
+                "laravel/framework": "^11.44.2 || ^12.7.2 || ^13",
                 "mockery/mockery": "^1.6.12",
                 "nikic/php-parser": "^5.4",
-                "orchestra/canvas": "^v9.2.2 || ^10.0.1",
-                "orchestra/testbench-core": "^9.12.0 || ^10.1",
+                "orchestra/canvas": "^v9.2.2 || ^10.0.1 || ^11",
+                "orchestra/testbench-core": "^9.12.0 || ^10.1 || ^11",
                 "phpstan/phpstan-deprecation-rules": "^2.0.1",
-                "phpunit/phpunit": "^10.5.35 || ^11.5.15"
+                "phpunit/phpunit": "^10.5.35 || ^11.5.15 || ^12.5.8"
             },
             "suggest": {
                 "orchestra/testbench": "Using Larastan for analysing a package needs Testbench",
@@ -8681,7 +9725,7 @@
             ],
             "support": {
                 "issues": "https://github.com/larastan/larastan/issues",
-                "source": "https://github.com/larastan/larastan/tree/v3.9.2"
+                "source": "https://github.com/larastan/larastan/tree/v3.9.6"
             },
             "funding": [
                 {
@@ -8689,20 +9733,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-30T15:16:32+00:00"
+            "time": "2026-04-16T10:02:43+00:00"
         },
         {
             "name": "laravel/pail",
-            "version": "v1.2.6",
+            "version": "v1.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pail.git",
-                "reference": "aa71a01c309e7f66bc2ec4fb1a59291b82eb4abf"
+                "reference": "2f7d27dada8effc48b8c424445a69cca7007daaa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pail/zipball/aa71a01c309e7f66bc2ec4fb1a59291b82eb4abf",
-                "reference": "aa71a01c309e7f66bc2ec4fb1a59291b82eb4abf",
+                "url": "https://api.github.com/repos/laravel/pail/zipball/2f7d27dada8effc48b8c424445a69cca7007daaa",
+                "reference": "2f7d27dada8effc48b8c424445a69cca7007daaa",
                 "shasum": ""
             },
             "require": {
@@ -8769,20 +9813,20 @@
                 "issues": "https://github.com/laravel/pail/issues",
                 "source": "https://github.com/laravel/pail"
             },
-            "time": "2026-02-09T13:44:54+00:00"
+            "time": "2026-05-20T22:24:57+00:00"
         },
         {
             "name": "laravel/pint",
-            "version": "v1.27.1",
+            "version": "v1.29.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "54cca2de13790570c7b6f0f94f37896bee4abcb5"
+                "reference": "0770e9b7fafd50d4586881d456d6eb41c9247a80"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/54cca2de13790570c7b6f0f94f37896bee4abcb5",
-                "reference": "54cca2de13790570c7b6f0f94f37896bee4abcb5",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/0770e9b7fafd50d4586881d456d6eb41c9247a80",
+                "reference": "0770e9b7fafd50d4586881d456d6eb41c9247a80",
                 "shasum": ""
             },
             "require": {
@@ -8793,13 +9837,14 @@
                 "php": "^8.2.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.93.1",
-                "illuminate/view": "^12.51.0",
-                "larastan/larastan": "^3.9.2",
-                "laravel-zero/framework": "^12.0.5",
+                "friendsofphp/php-cs-fixer": "^3.95.1",
+                "illuminate/view": "^12.56.0",
+                "larastan/larastan": "^3.9.6",
+                "laravel-zero/framework": "^12.1.0",
                 "mockery/mockery": "^1.6.12",
-                "nunomaduro/termwind": "^2.3.3",
-                "pestphp/pest": "^3.8.5"
+                "nunomaduro/termwind": "^2.4.0",
+                "pestphp/pest": "^3.8.6",
+                "shipfastlabs/agent-detector": "^1.1.3"
             },
             "bin": [
                 "builds/pint"
@@ -8836,7 +9881,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2026-02-10T20:00:20+00:00"
+            "time": "2026-04-20T15:26:14+00:00"
         },
         {
             "name": "laravel/tinker",
@@ -9107,39 +10152,36 @@
         },
         {
             "name": "nunomaduro/collision",
-            "version": "v8.8.3",
+            "version": "v8.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/collision.git",
-                "reference": "1dc9e88d105699d0fee8bb18890f41b274f6b4c4"
+                "reference": "716af8f95a470e9094cfca09ed897b023be191a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/1dc9e88d105699d0fee8bb18890f41b274f6b4c4",
-                "reference": "1dc9e88d105699d0fee8bb18890f41b274f6b4c4",
+                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/716af8f95a470e9094cfca09ed897b023be191a5",
+                "reference": "716af8f95a470e9094cfca09ed897b023be191a5",
                 "shasum": ""
             },
             "require": {
-                "filp/whoops": "^2.18.1",
-                "nunomaduro/termwind": "^2.3.1",
+                "filp/whoops": "^2.18.4",
+                "nunomaduro/termwind": "^2.4.0",
                 "php": "^8.2.0",
-                "symfony/console": "^7.3.0"
+                "symfony/console": "^7.4.8 || ^8.0.8"
             },
             "conflict": {
-                "laravel/framework": "<11.44.2 || >=13.0.0",
-                "phpunit/phpunit": "<11.5.15 || >=13.0.0"
+                "laravel/framework": "<11.48.0 || >=14.0.0",
+                "phpunit/phpunit": "<11.5.50 || >=14.0.0"
             },
             "require-dev": {
-                "brianium/paratest": "^7.8.3",
-                "larastan/larastan": "^3.4.2",
-                "laravel/framework": "^11.44.2 || ^12.18",
-                "laravel/pint": "^1.22.1",
-                "laravel/sail": "^1.43.1",
-                "laravel/sanctum": "^4.1.1",
-                "laravel/tinker": "^2.10.1",
-                "orchestra/testbench-core": "^9.12.0 || ^10.4",
-                "pestphp/pest": "^3.8.2 || ^4.0.0",
-                "sebastian/environment": "^7.2.1 || ^8.0"
+                "brianium/paratest": "^7.8.5",
+                "larastan/larastan": "^3.9.6",
+                "laravel/framework": "^11.48.0 || ^12.56.0 || ^13.5.0",
+                "laravel/pint": "^1.29.1",
+                "orchestra/testbench-core": "^9.12.0 || ^10.12.1 || ^11.2.1",
+                "pestphp/pest": "^3.8.5 || ^4.4.3 || ^5.0.0",
+                "sebastian/environment": "^7.2.1 || ^8.0.4 || ^9.3.0"
             },
             "type": "library",
             "extra": {
@@ -9202,20 +10244,20 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2025-11-20T02:55:25+00:00"
+            "time": "2026-04-21T14:04:20+00:00"
         },
         {
             "name": "orchestra/canvas",
-            "version": "v10.1.1",
+            "version": "v10.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/canvas.git",
-                "reference": "6e63f56acd46b0ee842e922d0ebb18af8f7a60f6"
+                "reference": "7ac2f2d58f05b8fc4ef1fe673cbdab7603023729"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/canvas/zipball/6e63f56acd46b0ee842e922d0ebb18af8f7a60f6",
-                "reference": "6e63f56acd46b0ee842e922d0ebb18af8f7a60f6",
+                "url": "https://api.github.com/repos/orchestral/canvas/zipball/7ac2f2d58f05b8fc4ef1fe673cbdab7603023729",
+                "reference": "7ac2f2d58f05b8fc4ef1fe673cbdab7603023729",
                 "shasum": ""
             },
             "require": {
@@ -9225,8 +10267,8 @@
                 "illuminate/database": "^12.40.0",
                 "illuminate/filesystem": "^12.40.0",
                 "illuminate/support": "^12.40.0",
-                "orchestra/canvas-core": "^10.1.2",
-                "orchestra/sidekick": "^1.2.7",
+                "orchestra/canvas-core": "^10.2.0",
+                "orchestra/sidekick": "~1.1.23|~1.2.20",
                 "orchestra/testbench-core": "^10.8.0",
                 "php": "^8.2",
                 "symfony/polyfill-php83": "^1.33",
@@ -9276,22 +10318,22 @@
             "description": "Code Generators for Laravel Applications and Packages",
             "support": {
                 "issues": "https://github.com/orchestral/canvas/issues",
-                "source": "https://github.com/orchestral/canvas/tree/v10.1.1"
+                "source": "https://github.com/orchestral/canvas/tree/v10.2.0"
             },
-            "time": "2025-11-24T04:53:34+00:00"
+            "time": "2026-03-24T15:20:32+00:00"
         },
         {
             "name": "orchestra/canvas-core",
-            "version": "v10.1.2",
+            "version": "v10.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/canvas-core.git",
-                "reference": "af1ac73bb0e4f5a65eeb3aadc1030983c6ea0aea"
+                "reference": "11fdb579f4f2d4bd68a22bd206cabc32e7856e32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/canvas-core/zipball/af1ac73bb0e4f5a65eeb3aadc1030983c6ea0aea",
-                "reference": "af1ac73bb0e4f5a65eeb3aadc1030983c6ea0aea",
+                "url": "https://api.github.com/repos/orchestral/canvas-core/zipball/11fdb579f4f2d4bd68a22bd206cabc32e7856e32",
+                "reference": "11fdb579f4f2d4bd68a22bd206cabc32e7856e32",
                 "shasum": ""
             },
             "require": {
@@ -9299,7 +10341,7 @@
                 "composer/semver": "^3.0",
                 "illuminate/console": "^12.40.0",
                 "illuminate/support": "^12.40.0",
-                "orchestra/sidekick": "^1.2.0",
+                "orchestra/sidekick": "~1.1.23|~1.2.20",
                 "php": "^8.2",
                 "symfony/polyfill-php83": "^1.33"
             },
@@ -9308,7 +10350,7 @@
                 "laravel/pint": "^1.24",
                 "mockery/mockery": "^1.6.10",
                 "orchestra/testbench-core": "^10.8.0",
-                "phpstan/phpstan": "^2.1.14",
+                "phpstan/phpstan": "^2.1.17",
                 "phpunit/phpunit": "^11.5.12|^12.0.1",
                 "spatie/laravel-ray": "^1.40.2",
                 "symfony/yaml": "^7.2"
@@ -9343,9 +10385,9 @@
             "description": "Code Generators Builder for Laravel Applications and Packages",
             "support": {
                 "issues": "https://github.com/orchestral/canvas/issues",
-                "source": "https://github.com/orchestral/canvas-core/tree/v10.1.2"
+                "source": "https://github.com/orchestral/canvas-core/tree/v10.2.0"
             },
-            "time": "2025-11-24T04:41:15+00:00"
+            "time": "2026-03-06T13:48:13+00:00"
         },
         {
             "name": "orchestra/sidekick",
@@ -9408,27 +10450,27 @@
         },
         {
             "name": "orchestra/testbench",
-            "version": "v10.9.0",
+            "version": "v10.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench.git",
-                "reference": "040a37b60e1a9d7ae10b496407b6c3bb63b47038"
+                "reference": "d73b4426dacddd2c1f5e671e0efd7665b16d2b84"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench/zipball/040a37b60e1a9d7ae10b496407b6c3bb63b47038",
-                "reference": "040a37b60e1a9d7ae10b496407b6c3bb63b47038",
+                "url": "https://api.github.com/repos/orchestral/testbench/zipball/d73b4426dacddd2c1f5e671e0efd7665b16d2b84",
+                "reference": "d73b4426dacddd2c1f5e671e0efd7665b16d2b84",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.2",
                 "fakerphp/faker": "^1.23",
-                "laravel/framework": "^12.40.0",
+                "laravel/framework": "^12.55.0",
                 "mockery/mockery": "^1.6.10",
-                "orchestra/testbench-core": "^10.9.0",
+                "orchestra/testbench-core": "^10.11.0",
                 "orchestra/workbench": "^10.0.8",
                 "php": "^8.2",
-                "phpunit/phpunit": "^11.5.3|^12.0.1",
+                "phpunit/phpunit": "^11.5.3|^12.0.1|^13.0.0",
                 "symfony/process": "^7.2",
                 "symfony/yaml": "^7.2",
                 "vlucas/phpdotenv": "^5.6.1"
@@ -9457,22 +10499,22 @@
             ],
             "support": {
                 "issues": "https://github.com/orchestral/testbench/issues",
-                "source": "https://github.com/orchestral/testbench/tree/v10.9.0"
+                "source": "https://github.com/orchestral/testbench/tree/v10.11.0"
             },
-            "time": "2026-01-14T03:26:57+00:00"
+            "time": "2026-03-18T13:08:23+00:00"
         },
         {
             "name": "orchestra/testbench-core",
-            "version": "v10.9.0",
+            "version": "v10.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench-core.git",
-                "reference": "754d2b71601822d1f57f28119e4dea27ed1a5205"
+                "reference": "6b88b608ba794fcac18094c7d191591c852c286d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/754d2b71601822d1f57f28119e4dea27ed1a5205",
-                "reference": "754d2b71601822d1f57f28119e4dea27ed1a5205",
+                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/6b88b608ba794fcac18094c7d191591c852c286d",
+                "reference": "6b88b608ba794fcac18094c7d191591c852c286d",
                 "shasum": ""
             },
             "require": {
@@ -9484,19 +10526,19 @@
             },
             "conflict": {
                 "brianium/paratest": "<7.3.0|>=8.0.0",
-                "laravel/framework": "<12.40.0|>=13.0.0",
+                "laravel/framework": "<12.55.0|>=13.0.0",
                 "laravel/serializable-closure": "<1.3.0|>=2.0.0 <2.0.3|>=3.0.0",
                 "nunomaduro/collision": "<8.0.0|>=9.0.0",
-                "phpunit/phpunit": "<10.5.35|>=11.0.0 <11.5.3|12.0.0|>=12.6.0"
+                "phpunit/phpunit": "<10.5.35|>=11.0.0 <11.5.3|12.0.0|>=13.2.0"
             },
             "require-dev": {
                 "fakerphp/faker": "^1.24",
-                "laravel/framework": "^12.40.0",
+                "laravel/framework": "^12.55.0",
                 "laravel/pint": "^1.24",
                 "laravel/serializable-closure": "^1.3|^2.0.4",
                 "mockery/mockery": "^1.6.10",
-                "phpstan/phpstan": "^2.1.33",
-                "phpunit/phpunit": "^10.5.35|^11.5.3|^12.0.1",
+                "phpstan/phpstan": "^2.1.38",
+                "phpunit/phpunit": "^10.5.35|^11.5.3|^12.0.1|^13.0.0",
                 "spatie/laravel-ray": "^1.42.0",
                 "symfony/process": "^7.2.0",
                 "symfony/yaml": "^7.2.0",
@@ -9506,11 +10548,11 @@
                 "brianium/paratest": "Allow using parallel testing (^7.3).",
                 "ext-pcntl": "Required to use all features of the console signal trapping.",
                 "fakerphp/faker": "Allow using Faker for testing (^1.23).",
-                "laravel/framework": "Required for testing (^12.40.0).",
+                "laravel/framework": "Required for testing (^12.55.0).",
                 "mockery/mockery": "Allow using Mockery for testing (^1.6).",
                 "nunomaduro/collision": "Allow using Laravel style tests output and parallel testing (^8.0).",
                 "orchestra/testbench-dusk": "Allow using Laravel Dusk for testing (^10.0).",
-                "phpunit/phpunit": "Allow using PHPUnit for testing (^10.5.35|^11.5.3|^12.0.1).",
+                "phpunit/phpunit": "Allow using PHPUnit for testing (^10.5.35|^11.5.3|^12.0.1|^13.0.0).",
                 "symfony/process": "Required to use Orchestra\\Testbench\\remote function (^7.2).",
                 "symfony/yaml": "Required for Testbench CLI (^7.2).",
                 "vlucas/phpdotenv": "Required for Testbench CLI (^5.6.1)."
@@ -9552,20 +10594,20 @@
                 "issues": "https://github.com/orchestral/testbench/issues",
                 "source": "https://github.com/orchestral/testbench-core"
             },
-            "time": "2026-01-13T05:19:42+00:00"
+            "time": "2026-04-24T08:35:55+00:00"
         },
         {
             "name": "orchestra/workbench",
-            "version": "v10.0.8",
+            "version": "v10.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/workbench.git",
-                "reference": "88bb9b5872539dd8b556b232a1b466f639c18259"
+                "reference": "bb5025efd9ea83610b87b3287956d90170b464e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/workbench/zipball/88bb9b5872539dd8b556b232a1b466f639c18259",
-                "reference": "88bb9b5872539dd8b556b232a1b466f639c18259",
+                "url": "https://api.github.com/repos/orchestral/workbench/zipball/bb5025efd9ea83610b87b3287956d90170b464e6",
+                "reference": "bb5025efd9ea83610b87b3287956d90170b464e6",
                 "shasum": ""
             },
             "require": {
@@ -9575,9 +10617,10 @@
                 "laravel/pail": "^1.2.2",
                 "laravel/tinker": "^2.10.1",
                 "nunomaduro/collision": "^8.6",
-                "orchestra/canvas": "^10.1.1",
+                "orchestra/canvas": "^10.2.0",
+                "orchestra/canvas-core": "^10.2.0",
                 "orchestra/sidekick": "~1.1.23|~1.2.20",
-                "orchestra/testbench-core": "^10.8.0",
+                "orchestra/testbench-core": "^10.12.0",
                 "php": "^8.2",
                 "symfony/polyfill-php83": "^1.33",
                 "symfony/process": "^7.2",
@@ -9618,9 +10661,9 @@
             ],
             "support": {
                 "issues": "https://github.com/orchestral/workbench/issues",
-                "source": "https://github.com/orchestral/workbench/tree/v10.0.8"
+                "source": "https://github.com/orchestral/workbench/tree/v10.1.0"
             },
-            "time": "2026-01-12T14:48:09+00:00"
+            "time": "2026-03-24T23:02:25+00:00"
         },
         {
             "name": "pdepend/pdepend",
@@ -9887,59 +10930,12 @@
             "time": "2023-12-11T08:22:20+00:00"
         },
         {
-            "name": "phpstan/phpdoc-parser",
-            "version": "2.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
-                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/annotations": "^2.0",
-                "nikic/php-parser": "^5.3.0",
-                "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^2.0",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^9.6",
-                "symfony/process": "^5.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "PHPStan\\PhpDocParser\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "PHPDoc parser with support for nullable, intersection and generic types",
-            "support": {
-                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
-            },
-            "time": "2026-01-25T14:56:51+00:00"
-        },
-        {
             "name": "phpstan/phpstan",
-            "version": "2.1.39",
+            "version": "2.1.56",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c6f73a2af4cbcd99c931d0fb8f08548cc0fa8224",
-                "reference": "c6f73a2af4cbcd99c931d0fb8f08548cc0fa8224",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/93a603c9fc3be8c3c93bbc8d22170ad766685537",
+                "reference": "93a603c9fc3be8c3c93bbc8d22170ad766685537",
                 "shasum": ""
             },
             "require": {
@@ -9984,20 +10980,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-11T14:48:56+00:00"
+            "time": "2026-05-26T17:04:57+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "12.5.3",
+            "version": "12.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "b015312f28dd75b75d3422ca37dff2cd1a565e8d"
+                "reference": "876099a072646c7745f673d7aeab5382c4439691"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/b015312f28dd75b75d3422ca37dff2cd1a565e8d",
-                "reference": "b015312f28dd75b75d3422ca37dff2cd1a565e8d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/876099a072646c7745f673d7aeab5382c4439691",
+                "reference": "876099a072646c7745f673d7aeab5382c4439691",
                 "shasum": ""
             },
             "require": {
@@ -10006,7 +11002,6 @@
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^5.7.0",
                 "php": ">=8.3",
-                "phpunit/php-file-iterator": "^6.0",
                 "phpunit/php-text-template": "^5.0",
                 "sebastian/complexity": "^5.0",
                 "sebastian/environment": "^8.0.3",
@@ -10053,7 +11048,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.3"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.6"
             },
             "funding": [
                 {
@@ -10073,7 +11068,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-06T06:01:44+00:00"
+            "time": "2026-04-15T08:23:17+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -10334,16 +11329,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.5.12",
+            "version": "12.5.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "418e06b3b46b0d54bad749ff4907fc7dfb530199"
+                "reference": "5895d05f5bf421ed230fbd76e1277e4b8955def4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/418e06b3b46b0d54bad749ff4907fc7dfb530199",
-                "reference": "418e06b3b46b0d54bad749ff4907fc7dfb530199",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5895d05f5bf421ed230fbd76e1277e4b8955def4",
+                "reference": "5895d05f5bf421ed230fbd76e1277e4b8955def4",
                 "shasum": ""
             },
             "require": {
@@ -10357,20 +11352,20 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.3",
-                "phpunit/php-code-coverage": "^12.5.3",
+                "phpunit/php-code-coverage": "^12.5.6",
                 "phpunit/php-file-iterator": "^6.0.1",
                 "phpunit/php-invoker": "^6.0.0",
                 "phpunit/php-text-template": "^5.0.0",
                 "phpunit/php-timer": "^8.0.0",
-                "sebastian/cli-parser": "^4.2.0",
-                "sebastian/comparator": "^7.1.4",
+                "sebastian/cli-parser": "^4.2.1",
+                "sebastian/comparator": "^7.1.8",
                 "sebastian/diff": "^7.0.0",
-                "sebastian/environment": "^8.0.3",
-                "sebastian/exporter": "^7.0.2",
+                "sebastian/environment": "^8.1.2",
+                "sebastian/exporter": "^7.0.3",
                 "sebastian/global-state": "^8.0.2",
                 "sebastian/object-enumerator": "^7.0.0",
                 "sebastian/recursion-context": "^7.0.1",
-                "sebastian/type": "^6.0.3",
+                "sebastian/type": "^6.0.4",
                 "sebastian/version": "^6.0.0",
                 "staabm/side-effects-detector": "^1.0.5"
             },
@@ -10412,44 +11407,28 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.12"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.28"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/sponsors.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
-                    "type": "tidelift"
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
                 }
             ],
-            "time": "2026-02-16T08:34:36+00:00"
+            "time": "2026-05-27T14:01:10+00:00"
         },
         {
             "name": "psy/psysh",
-            "version": "v0.12.20",
+            "version": "v0.12.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "19678eb6b952a03b8a1d96ecee9edba518bb0373"
+                "reference": "4dcc0f08047d52bbde475eda481146fd8e27e1a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/19678eb6b952a03b8a1d96ecee9edba518bb0373",
-                "reference": "19678eb6b952a03b8a1d96ecee9edba518bb0373",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/4dcc0f08047d52bbde475eda481146fd8e27e1a4",
+                "reference": "4dcc0f08047d52bbde475eda481146fd8e27e1a4",
                 "shasum": ""
             },
             "require": {
@@ -10513,29 +11492,29 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.12.20"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.12.23"
             },
-            "time": "2026-02-11T15:05:28+00:00"
+            "time": "2026-05-23T13:41:31+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "4.2.0",
+            "version": "4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04"
+                "reference": "7d05781b13f7dec9043a629a21d086ed74582a15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/90f41072d220e5c40df6e8635f5dafba2d9d4d04",
-                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/7d05781b13f7dec9043a629a21d086ed74582a15",
+                "reference": "7d05781b13f7dec9043a629a21d086ed74582a15",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^12.5.25"
             },
             "type": "library",
             "extra": {
@@ -10564,7 +11543,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
                 "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.2.0"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.2.1"
             },
             "funding": [
                 {
@@ -10584,20 +11563,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-14T09:36:45+00:00"
+            "time": "2026-05-17T05:29:34+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "7.1.4",
+            "version": "7.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "6a7de5df2e094f9a80b40a522391a7e6022df5f6"
+                "reference": "7c65c1e79836812819705b473a90c12399542485"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/6a7de5df2e094f9a80b40a522391a7e6022df5f6",
-                "reference": "6a7de5df2e094f9a80b40a522391a7e6022df5f6",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/7c65c1e79836812819705b473a90c12399542485",
+                "reference": "7c65c1e79836812819705b473a90c12399542485",
                 "shasum": ""
             },
             "require": {
@@ -10605,10 +11584,10 @@
                 "ext-mbstring": "*",
                 "php": ">=8.3",
                 "sebastian/diff": "^7.0",
-                "sebastian/exporter": "^7.0"
+                "sebastian/exporter": "^7.0.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.2"
+                "phpunit/phpunit": "^12.5.25"
             },
             "suggest": {
                 "ext-bcmath": "For comparing BcMath\\Number objects"
@@ -10656,7 +11635,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.4"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.8"
             },
             "funding": [
                 {
@@ -10676,7 +11655,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-24T09:28:48+00:00"
+            "time": "2026-05-21T04:45:25+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -10805,23 +11784,23 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "8.0.3",
+            "version": "8.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "24a711b5c916efc6d6e62aa65aa2ec98fef77f68"
+                "reference": "9d32c685773823b1983e256ae4ecd48a10d6e439"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/24a711b5c916efc6d6e62aa65aa2ec98fef77f68",
-                "reference": "24a711b5c916efc6d6e62aa65aa2ec98fef77f68",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/9d32c685773823b1983e256ae4ecd48a10d6e439",
+                "reference": "9d32c685773823b1983e256ae4ecd48a10d6e439",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^12.5.26"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -10829,7 +11808,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "8.0-dev"
+                    "dev-main": "8.1-dev"
                 }
             },
             "autoload": {
@@ -10857,7 +11836,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/8.0.3"
+                "source": "https://github.com/sebastianbergmann/environment/tree/8.1.2"
             },
             "funding": [
                 {
@@ -10877,29 +11856,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-12T14:11:56+00:00"
+            "time": "2026-05-25T13:40:20+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "7.0.2",
+            "version": "7.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "016951ae10980765e4e7aee491eb288c64e505b7"
+                "reference": "c5e21b5de653ce0a769fb36f5cdfcb5e7a32cf23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/016951ae10980765e4e7aee491eb288c64e505b7",
-                "reference": "016951ae10980765e4e7aee491eb288c64e505b7",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/c5e21b5de653ce0a769fb36f5cdfcb5e7a32cf23",
+                "reference": "c5e21b5de653ce0a769fb36f5cdfcb5e7a32cf23",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "php": ">=8.3",
-                "sebastian/recursion-context": "^7.0"
+                "sebastian/recursion-context": "^7.0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^12.5.25"
             },
             "type": "library",
             "extra": {
@@ -10947,7 +11926,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/7.0.2"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/7.0.3"
             },
             "funding": [
                 {
@@ -10967,7 +11946,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:16:11+00:00"
+            "time": "2026-05-20T04:37:17+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -11045,24 +12024,24 @@
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "4.0.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "97ffee3bcfb5805568d6af7f0f893678fc076d2f"
+                "reference": "d543b8ef219dcd8da262cbb958639a96bedba10e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/97ffee3bcfb5805568d6af7f0f893678fc076d2f",
-                "reference": "97ffee3bcfb5805568d6af7f0f893678fc076d2f",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d543b8ef219dcd8da262cbb958639a96bedba10e",
+                "reference": "d543b8ef219dcd8da262cbb958639a96bedba10e",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^5.0",
+                "nikic/php-parser": "^5.7.0",
                 "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^12.5.25"
             },
             "type": "library",
             "extra": {
@@ -11091,15 +12070,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
                 "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/4.0.0"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/4.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/lines-of-code",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:57:28+00:00"
+            "time": "2026-05-19T16:22:07+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -11293,23 +12284,23 @@
         },
         {
             "name": "sebastian/type",
-            "version": "6.0.3",
+            "version": "6.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d"
+                "reference": "82ff822c2edc46724be9f7411d3163021f602773"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/e549163b9760b8f71f191651d22acf32d56d6d4d",
-                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/82ff822c2edc46724be9f7411d3163021f602773",
+                "reference": "82ff822c2edc46724be9f7411d3163021f602773",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^12.5.25"
             },
             "type": "library",
             "extra": {
@@ -11338,7 +12329,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
                 "security": "https://github.com/sebastianbergmann/type/security/policy",
-                "source": "https://github.com/sebastianbergmann/type/tree/6.0.3"
+                "source": "https://github.com/sebastianbergmann/type/tree/6.0.4"
             },
             "funding": [
                 {
@@ -11358,7 +12349,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-09T06:57:12+00:00"
+            "time": "2026-05-20T06:45:45+00:00"
         },
         {
             "name": "sebastian/version",
@@ -11547,16 +12538,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v7.4.4",
+            "version": "v7.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "4275b53b8ab0cf37f48bf273dc2285c8178efdfb"
+                "reference": "d91b6c7cd2a8c9a9c2b8d26c8f5ed48edf99ef57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/4275b53b8ab0cf37f48bf273dc2285c8178efdfb",
-                "reference": "4275b53b8ab0cf37f48bf273dc2285c8178efdfb",
+                "url": "https://api.github.com/repos/symfony/config/zipball/d91b6c7cd2a8c9a9c2b8d26c8f5ed48edf99ef57",
+                "reference": "d91b6c7cd2a8c9a9c2b8d26c8f5ed48edf99ef57",
                 "shasum": ""
             },
             "require": {
@@ -11602,7 +12593,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v7.4.4"
+                "source": "https://github.com/symfony/config/tree/v7.4.10"
             },
             "funding": [
                 {
@@ -11622,20 +12613,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-13T11:36:38+00:00"
+            "time": "2026-05-03T14:20:49+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v7.4.5",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "76a02cddca45a5254479ad68f9fa274ead0a7ef2"
+                "reference": "f299e20ce983be6c0744952533c6dfeaaa1448e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/76a02cddca45a5254479ad68f9fa274ead0a7ef2",
-                "reference": "76a02cddca45a5254479ad68f9fa274ead0a7ef2",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/f299e20ce983be6c0744952533c6dfeaaa1448e2",
+                "reference": "f299e20ce983be6c0744952533c6dfeaaa1448e2",
                 "shasum": ""
             },
             "require": {
@@ -11686,7 +12677,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.5"
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -11706,20 +12697,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-27T16:16:02+00:00"
+            "time": "2026-05-20T14:07:29+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.4.0",
+            "version": "v7.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "d551b38811096d0be9c4691d406991b47c0c630a"
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d551b38811096d0be9c4691d406991b47c0c630a",
-                "reference": "d551b38811096d0be9c4691d406991b47c0c630a",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
                 "shasum": ""
             },
             "require": {
@@ -11756,7 +12747,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.4.0"
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.11"
             },
             "funding": [
                 {
@@ -11776,20 +12767,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-27T13:27:24+00:00"
+            "time": "2026-05-11T16:38:44+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.4.1",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "24dd4de28d2e3988b311751ac49e684d783e2345"
+                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/24dd4de28d2e3988b311751ac49e684d783e2345",
-                "reference": "24dd4de28d2e3988b311751ac49e684d783e2345",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
+                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
                 "shasum": ""
             },
             "require": {
@@ -11832,7 +12823,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.4.1"
+                "source": "https://github.com/symfony/yaml/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -11852,7 +12843,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-04T18:11:45+00:00"
+            "time": "2026-05-25T06:06:12+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -11906,16 +12897,16 @@
         },
         {
             "name": "zircote/swagger-php",
-            "version": "5.8.2",
+            "version": "5.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zircote/swagger-php.git",
-                "reference": "18ee6592518238a5a6c9905aae4926d5bbc65754"
+                "reference": "098223019f764a16715f64089a58606096719c98"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/18ee6592518238a5a6c9905aae4926d5bbc65754",
-                "reference": "18ee6592518238a5a6c9905aae4926d5bbc65754",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/098223019f764a16715f64089a58606096719c98",
+                "reference": "098223019f764a16715f64089a58606096719c98",
                 "shasum": ""
             },
             "require": {
@@ -11988,7 +12979,7 @@
             ],
             "support": {
                 "issues": "https://github.com/zircote/swagger-php/issues",
-                "source": "https://github.com/zircote/swagger-php/tree/5.8.2"
+                "source": "https://github.com/zircote/swagger-php/tree/5.8.3"
             },
             "funding": [
                 {
@@ -11996,7 +12987,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-10T20:10:15+00:00"
+            "time": "2026-03-02T00:47:18+00:00"
         }
     ],
     "aliases": [],

--- a/config/user-authentication.php
+++ b/config/user-authentication.php
@@ -56,7 +56,7 @@ return [
         'attestations' => array_map('strtolower', array_map('trim', array_filter(explode(',', env('USER_AUTH_PASSKEY_ATTESTATIONS', 'none')), 'strlen'))), // none,packed, fido
         // Full origins (scheme://host[:port]) allowed to perform WebAuthn ceremonies.
         // Must include the origin where the frontend is served, e.g. https://app.example.com
-        'allowed_origins' => array_map('strtolower', array_map('trim', array_filter(explode(',', env('USER_AUTH_PASSKEY_ALLOWED_ORIGINS', '')), 'strlen'))), // localhost, google.com, etc..
+        'allowed_origins' => array_map('strtolower', array_map('trim', array_filter(explode(',', env('USER_AUTH_PASSKEY_ALLOWED_ORIGINS', '')), 'strlen'))), // Must be full origins, e.g. https://localhost, https://app.example.com
         // Whether to request discoverable (resident) credentials.
         // Required for passwordless login without entering an email first.
         'resident_keys' => env('USER_AUTH_PASSKEY_RESIDENT_KEYS', false),

--- a/config/user-authentication.php
+++ b/config/user-authentication.php
@@ -49,4 +49,10 @@ return [
         'mode' => env('USER_AUTH_EMAIL_RESTRICTION_MODE', null), // 'whitelist', 'blacklist', or null
         'domains' => array_map('strtolower', array_map('trim', array_filter(explode(',', env('USER_AUTH_EMAIL_RESTRICTION_DOMAINS', '')), 'strlen'))),
     ],
+
+    'passkey' => [
+        'domain' => env('USER_AUTH_PASSKEY_DOMAIN', 'localhost'),
+        'attestations' => array_map('strtolower', array_map('trim', array_filter(explode(',', env('USER_AUTH_PASSKEY_ATTESTATIONS', 'none')), 'strlen'))), // none,packed, fido
+        'allowed_origins' => array_map('strtolower', array_map('trim', array_filter(explode(',', env('USER_AUTH_PASSKEY_ALLOWED_ORIGINS', '')), 'strlen'))), // localhost, google.com, etc...
+    ]
 ];

--- a/config/user-authentication.php
+++ b/config/user-authentication.php
@@ -51,6 +51,7 @@ return [
     ],
 
     'passkey' => [
+        'session_lifetime'=> env('USER_AUTH_PASSKEY_SESSION_LIFETIME', 5), // in minutes
         'domain' => env('USER_AUTH_PASSKEY_DOMAIN', 'localhost'),
         'attestations' => array_map('strtolower', array_map('trim', array_filter(explode(',', env('USER_AUTH_PASSKEY_ATTESTATIONS', 'none')), 'strlen'))), // none,packed, fido
         'allowed_origins' => array_map('strtolower', array_map('trim', array_filter(explode(',', env('USER_AUTH_PASSKEY_ALLOWED_ORIGINS', '')), 'strlen'))), // localhost, google.com, etc...

--- a/config/user-authentication.php
+++ b/config/user-authentication.php
@@ -51,9 +51,14 @@ return [
     ],
 
     'passkey' => [
-        'session_lifetime'=> env('USER_AUTH_PASSKEY_SESSION_LIFETIME', 5), // in minutes
-        'domain' => env('USER_AUTH_PASSKEY_DOMAIN', 'localhost'),
+        'session_lifetime' => env('USER_AUTH_PASSKEY_SESSION_LIFETIME', 5), // in minutes
+        'domain' => env('USER_AUTH_PASSKEY_DOMAIN', ''),
         'attestations' => array_map('strtolower', array_map('trim', array_filter(explode(',', env('USER_AUTH_PASSKEY_ATTESTATIONS', 'none')), 'strlen'))), // none,packed, fido
-        'allowed_origins' => array_map('strtolower', array_map('trim', array_filter(explode(',', env('USER_AUTH_PASSKEY_ALLOWED_ORIGINS', '')), 'strlen'))), // localhost, google.com, etc...
+        // Full origins (scheme://host[:port]) allowed to perform WebAuthn ceremonies.
+        // Must include the origin where the frontend is served, e.g. https://app.example.com
+        'allowed_origins' => array_map('strtolower', array_map('trim', array_filter(explode(',', env('USER_AUTH_PASSKEY_ALLOWED_ORIGINS', '')), 'strlen'))), // localhost, google.com, etc..
+        // Whether to request discoverable (resident) credentials.
+        // Required for passwordless login without entering an email first.
+        'resident_keys' => env('USER_AUTH_PASSKEY_RESIDENT_KEYS', false),
     ]
 ];

--- a/database/migrations/2026_05_27_161447_create_passkeys_table.php
+++ b/database/migrations/2026_05_27_161447_create_passkeys_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class () extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2026_05_27_161447_create_passkeys_table.php
+++ b/database/migrations/2026_05_27_161447_create_passkeys_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('passkeys', function (Blueprint $table) {
+            $table->id();
+            $table->string('keyable_type');
+            $table->unsignedBigInteger('keyable_id');
+            $table->text('name');
+            $table->string('credential_id'); // Should be binary?
+            $table->json('data');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('passkeys');
+    }
+};

--- a/database/migrations/2026_05_27_161447_create_passkeys_table.php
+++ b/database/migrations/2026_05_27_161447_create_passkeys_table.php
@@ -12,10 +12,9 @@ return new class () extends Migration {
     {
         Schema::create('passkeys', function (Blueprint $table) {
             $table->id();
-            $table->string('keyable_type');
-            $table->unsignedBigInteger('keyable_id');
-            $table->text('name');
-            $table->string('credential_id'); // Should be binary?
+            $table->morphs('keyable');
+            $table->string('name');
+            $table->string('credential_id')->unique();
             $table->json('data');
             $table->timestamps();
         });

--- a/docs.json
+++ b/docs.json
@@ -10,6 +10,7 @@
   "sidebar": [
     { "title": "Installation", "path": "docs/installation.md" },
     { "title": "Verification", "path": "docs/verification.md" },
+    { "title": "Passkeys", "path": "docs/passkey.md" },
     { "title": "Customization", "path": "docs/customization.md" }
   ]
 }

--- a/docs/passkey.md
+++ b/docs/passkey.md
@@ -22,6 +22,18 @@ This package supports WebAuthn passkeys for passwordless and second-factor authe
 
 Passkeys in this package are stored as WebAuthn credentials linked to the package's user model through a polymorphic relation. Each user can have multiple passkeys (e.g., one on their laptop, one on their phone).
 
+If you configure a custom user model via `user-authentication.user_model`, the model must use the `Whilesmart\UserAuthentication\Traits\HasPasskeys` trait so the passkey relation is available:
+
+```php
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Whilesmart\UserAuthentication\Traits\HasPasskeys;
+
+class User extends Authenticatable
+{
+    use HasPasskeys;
+}
+```
+
 Key features:
 
 - **Configurable resident credentials** — opt-in to discoverable credentials for true passwordless login, or keep them off for second-factor-only use.

--- a/docs/passkey.md
+++ b/docs/passkey.md
@@ -1,0 +1,330 @@
+# Passkey Authentication
+
+This package supports WebAuthn passkeys for passwordless and second-factor authentication. Passkeys are discoverable credentials that let users sign in with a biometric sensor, PIN, or security key.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Requirements](#requirements)
+- [Configuration](#configuration)
+- [Endpoints](#endpoints)
+- [Registration Flow](#registration-flow)
+- [Login Flow](#login-flow)
+  - [With Email](#with-email)
+  - [Passwordless](#passwordless)
+- [Frontend Integration](#frontend-integration)
+- [Origin and RP ID](#origin-and-rp-id)
+- [Security Considerations](#security-considerations)
+- [Troubleshooting](#troubleshooting)
+- [Local Development with ngrok](#local-development-with-ngrok)
+
+## Overview
+
+Passkeys in this package are stored as WebAuthn credentials linked to the package's user model through a polymorphic relation. Each user can have multiple passkeys (e.g., one on their laptop, one on their phone).
+
+Key features:
+
+- **Configurable resident credentials** — opt-in to discoverable credentials for true passwordless login, or keep them off for second-factor-only use.
+- **Email-based passkey login** — the backend filters the allowed credentials to those belonging to a specific user.
+- **Passwordless passkey login** — when resident keys are enabled, the backend returns an empty `allowCredentials` list, letting the browser show the passkey picker.
+
+## Requirements
+
+- PHP 8.3+
+- `web-auth/webauthn-lib` is installed automatically with the package.
+- A browser and authenticator that support WebAuthn (Chrome, Edge, Safari, Firefox; Touch ID, Windows Hello, YubiKey, etc.).
+- For mobile and roaming authenticators, the frontend must be served over **HTTPS** (or `localhost` for some browsers).
+
+## Configuration
+
+All passkey settings live under the `passkey` key in `config/user-authentication.php` and are driven by environment variables.
+
+```php
+'passkey' => [
+    'session_lifetime' => env('USER_AUTH_PASSKEY_SESSION_LIFETIME', 5), // minutes
+    'domain' => env('USER_AUTH_PASSKEY_DOMAIN', 'localhost'),
+    'attestations' => array_map('strtolower', array_map('trim', array_filter(explode(',', env('USER_AUTH_PASSKEY_ATTESTATIONS', 'none')), 'strlen'))),
+    'allowed_origins' => array_map('strtolower', array_map('trim', array_filter(explode(',', env('USER_AUTH_PASSKEY_ALLOWED_ORIGINS', '')), 'strlen'))),
+],
+```
+
+### Environment Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `USER_AUTH_PASSKEY_SESSION_LIFETIME` | `5` | How many minutes the server-side registration/login challenge is cached. |
+| `USER_AUTH_PASSKEY_DOMAIN` | (empty) | The relying party ID (RP ID) host. Must include the scheme, e.g. `https://app.example.com`. |
+| `USER_AUTH_PASSKEY_ALLOWED_ORIGINS` | (empty) | Full origins (scheme + host + port) allowed to perform WebAuthn ceremonies. Required for HTTPS deployments. |
+| `USER_AUTH_PASSKEY_ATTESTATIONS` | `none` | Comma-separated attestation formats. Options: `none`, `packed`, `fido`. |
+| `USER_AUTH_PASSKEY_RESIDENT_KEYS` | `false` | Request discoverable (resident) credentials. Required for passwordless login without email. |
+
+### Important: include the scheme in `USER_AUTH_PASSKEY_DOMAIN`
+
+The backend extracts the RP ID host with PHP's `parse_url()`. If you provide a bare hostname such as `app.example.com`, `parse_url()` returns `null` for the host and the `rp.id` is dropped from the registration options. The browser then falls back to the origin's effective domain, while the server verification may use a different host, causing an **"rpId hash mismatch"** error.
+
+Always set the domain with a scheme:
+
+```bash
+# Good
+USER_AUTH_PASSKEY_DOMAIN=https://app.example.com
+
+# Bad — will drop rp.id
+USER_AUTH_PASSKEY_DOMAIN=app.example.com
+```
+
+For local HTTPS tunnels such as ngrok, set both the frontend origin and domain to the ngrok URL:
+
+```bash
+USER_AUTH_PASSKEY_ALLOWED_ORIGINS=https://abc123.ngrok-free.app
+USER_AUTH_PASSKEY_DOMAIN=https://abc123.ngrok-free.app
+```
+
+## Endpoints
+
+All passkey endpoints are prefixed with the configured route prefix (default: `api`).
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| `POST` | `/passkeys/register/options` | Yes | Get WebAuthn creation options for the authenticated user. |
+| `POST` | `/passkeys/register` | Yes | Store a new passkey for the authenticated user. |
+| `POST` | `/passkeys/login/options` | No | Get WebAuthn request options. Email is optional for passwordless flow. |
+| `POST` | `/passkeys/login` | No | Verify a passkey assertion and return a Sanctum token. |
+| `GET`  | `/passkeys` | Yes | List the authenticated user's passkeys. |
+| `DELETE` | `/passkeys/{id}` | Yes | Delete a passkey. |
+
+## Registration Flow
+
+Passkey registration must happen while the user is authenticated, because the credential is attached to their account.
+
+### 1. Get registration options
+
+```bash
+curl -X POST https://app.example.com/api/passkeys/register/options \
+  -H "Authorization: Bearer {token}" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"MacBook Touch ID"}'
+```
+
+Response:
+
+```json
+{
+  "status": "success",
+  "data": {
+    "options": "{\"challenge\":\"...\",\"rp\":{\"name\":\"Laravel\",\"id\":\"app.example.com\"},\"user\":{...},...}",
+    "session_id": "reg_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  }
+}
+```
+
+The `options` value is a JSON string. Parse it on the frontend and convert base64url fields to `ArrayBuffer` before calling the WebAuthn API.
+
+### 2. Create the credential in the browser
+
+```javascript
+const publicKey = JSON.parse(options);
+publicKey.challenge = base64urlToArrayBuffer(publicKey.challenge);
+publicKey.user.id = base64urlToArrayBuffer(publicKey.user.id);
+
+const credential = await navigator.credentials.create({ publicKey });
+```
+
+### 3. Send the credential to the server
+
+Convert the credential's binary fields back to base64url and POST them:
+
+```bash
+curl -X POST https://app.example.com/api/passkeys/register \
+  -H "Authorization: Bearer {token}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "session_id": "reg_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "name": "MacBook Touch ID",
+    "passkey": {
+      "id": "...",
+      "rawId": "...",
+      "type": "public-key",
+      "response": {
+        "clientDataJSON": "...",
+        "attestationObject": "...",
+        "transports": ["internal"]
+      }
+    }
+  }'
+```
+
+## Login Flow
+
+### With Email
+
+When the email is provided, the backend returns only that user's credentials, which is useful if you want to keep a traditional username/email step.
+
+#### 1. Get login options
+
+```bash
+curl -X POST https://app.example.com/api/passkeys/login/options \
+  -H "Content-Type: application/json" \
+  -d '{"email":"user@example.com"}'
+```
+
+#### 2. Get the credential
+
+```javascript
+const publicKey = JSON.parse(options);
+publicKey.challenge = base64urlToArrayBuffer(publicKey.challenge);
+publicKey.allowCredentials.forEach(c => c.id = base64urlToArrayBuffer(c.id));
+
+const credential = await navigator.credentials.get({ publicKey });
+```
+
+#### 3. Verify the assertion
+
+```bash
+curl -X POST https://app.example.com/api/passkeys/login \
+  -H "Content-Type: application/json" \
+  -d '{
+    "session_id": "log_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "passkey": {
+      "id": "...",
+      "rawId": "...",
+      "type": "public-key",
+      "response": {
+        "clientDataJSON": "...",
+        "authenticatorData": "...",
+        "signature": "...",
+        "userHandle": "..."
+      }
+    }
+  }'
+```
+
+Response includes a Sanctum bearer token:
+
+```json
+{
+  "status": "success",
+  "data": {
+    "token": "...",
+    "token_type": "Bearer",
+    "user": { ... }
+  }
+}
+```
+
+### Passwordless
+
+Omit the email from the login-options request. The backend returns an empty `allowCredentials` list, which tells the browser to show the passkey picker and use any discoverable credential.
+
+This requires resident keys to be enabled:
+
+```bash
+USER_AUTH_PASSKEY_RESIDENT_KEYS=true
+```
+
+```bash
+curl -X POST https://app.example.com/api/passkeys/login/options \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+The rest of the flow is identical to the email-based flow.
+
+## Frontend Integration
+
+The key pieces of a passkey frontend implementation are:
+
+1. **Convert server options to WebAuthn format** — base64url strings must become `ArrayBuffer`s.
+2. **Convert the browser credential back to JSON** — binary fields become base64url strings.
+3. **Call the API** — send requests to the route prefix configured in the package (default `/api`).
+
+### Base64url helpers
+
+```javascript
+function base64urlToArrayBuffer(base64url) {
+  const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
+  const bin = atob(base64);
+  const buf = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) buf[i] = bin.charCodeAt(i);
+  return buf.buffer;
+}
+
+function arrayBufferToBase64url(buf) {
+  const bytes = new Uint8Array(buf);
+  let bin = '';
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+```
+
+## Origin and RP ID
+
+WebAuthn is strict about the relationship between the frontend origin and the RP ID.
+
+- **Origin** — the scheme + host + port where the JavaScript runs (`https://app.example.com`).
+- **RP ID** — the host component extracted from `USER_AUTH_PASSKEY_DOMAIN` (`app.example.com`).
+
+The browser requires the origin's host to match or be a registrable domain suffix of the RP ID. The server verifies the same relationship through `allowed_origins`.
+
+### Example setups
+
+#### Local HTTPS development with ngrok
+
+Frontend tunnel: `https://abc123.ngrok-free.app -> http://localhost:5173`
+Backend: `http://localhost:8000`
+
+```bash
+USER_AUTH_PASSKEY_ALLOWED_ORIGINS=https://abc123.ngrok-free.app
+USER_AUTH_PASSKEY_DOMAIN=https://abc123.ngrok-free.app
+```
+
+The frontend must be opened through the ngrok HTTPS URL, not `localhost:5173`.
+
+#### Production
+
+```bash
+USER_AUTH_PASSKEY_ALLOWED_ORIGINS=https://app.example.com
+USER_AUTH_PASSKEY_DOMAIN=https://app.example.com
+```
+
+#### Bare hostname bug
+
+If you set only the bare hostname:
+
+```bash
+USER_AUTH_PASSKEY_DOMAIN=app.example.com
+```
+
+the backend extracts `null` as the RP ID and the registration options omit `rp.id`. The browser then uses the origin host (`app.example.com`) while the server verification may use the request host, producing an **"rpId hash mismatch"** error.
+
+## Security Considerations
+
+- **HTTPS in production** — WebAuthn requires a secure origin in all modern browsers.
+- **Allowed origins** — restrict `USER_AUTH_PASSKEY_ALLOWED_ORIGINS` to your actual frontend origins. Do not use wildcard origins.
+- **RP ID scope** — choosing a broad RP ID (e.g., `example.com`) makes the passkey usable across all subdomains. Choose the narrowest RP ID that fits your architecture.
+- **Resident keys** — when `USER_AUTH_PASSKEY_RESIDENT_KEYS=true`, the package requests discoverable credentials (`residentKey: required`). This stores user-identifying information on the authenticator; ensure this aligns with your privacy policy.
+- **Session lifetime** — the challenge cache is short (5 minutes by default). Do not increase it significantly.
+
+## Troubleshooting
+
+### "rpId hash mismatch"
+
+- `USER_AUTH_PASSKEY_DOMAIN` is missing the scheme. Use `https://app.example.com`, not `app.example.com`.
+- The frontend origin does not match the configured RP ID or allowed origins.
+- You are opening the frontend through a different URL than the one configured (e.g., `localhost:5173` instead of the ngrok URL).
+
+### "Invalid origin"
+
+- `USER_AUTH_PASSKEY_ALLOWED_ORIGINS` does not include the frontend origin.
+- The frontend is served over HTTP but the origin is not `localhost`.
+
+### "This passkey is not valid"
+
+- The session ID expired or was not sent back.
+- The credential ID does not exist in the database.
+- The assertion signature could not be verified. Check the Laravel logs for the exact WebAuthn error.
+
+### Passkey picker does not appear for passwordless login
+
+- `USER_AUTH_PASSKEY_RESIDENT_KEYS` is not set to `true`. Passwordless login requires discoverable credentials.
+- The passkey was not created as a discoverable credential. The package requests `residentKey: required` when resident keys are enabled, but the authenticator may ignore this if it does not support resident keys.
+- The browser has no discoverable credentials for the RP ID.

--- a/routes/user-authentication.php
+++ b/routes/user-authentication.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use Whilesmart\UserAuthentication\Http\Controllers\Auth\AuthController;
+use Whilesmart\UserAuthentication\Http\Controllers\Auth\PasskeyController;
 use Whilesmart\UserAuthentication\Http\Controllers\Auth\PasswordResetController;
 
 /*
@@ -22,8 +23,15 @@ Route::post('/send-verification-code', [AuthController::class, 'sendVerification
 Route::post('/verify-code', [AuthController::class, 'verifyCode']);
 Route::post('/password/reset-code', [PasswordResetController::class, 'sendPasswordResetCode']);
 Route::post('/password/reset', [PasswordResetController::class, 'resetPasswordWithCode']);
+Route::post('/passkeys/login/options', [PasskeyController::class, 'loginOptions']);
+Route::post('/passkeys/login', [PasskeyController::class, 'login']);
 
 // Resource routes
 Route::group(['middleware' => ['auth:sanctum']], function () {
     Route::post('logout', [AuthController::class, 'logout']);
+
+    Route::post('/passkeys/register/options', [PasskeyController::class, 'registerOptions']);
+    Route::post('/passkeys/register', [PasskeyController::class, 'register']);
+    Route::delete('/passkeys/{id}', [PasskeyController::class, 'destroy']);
+    Route::get('/passkeys', [PasskeyController::class, 'index']);
 });

--- a/src/Documentation/UserAuthOpenApiDocs.php
+++ b/src/Documentation/UserAuthOpenApiDocs.php
@@ -15,6 +15,7 @@ use OpenApi\Attributes as OA;
  * @codeCoverageIgnore
  */
 #[OA\Tag(name: 'Authentication', description: 'Endpoints for user authentication')]
+#[OA\Tag(name: 'Passkey', description: 'Endpoints for WebAuthn passkey management')]
 class UserAuthOpenApiDocs
 {
     #[OA\Post(
@@ -243,6 +244,404 @@ class UserAuthOpenApiDocs
         ]
     )]
     public function verifyCode()
+    {
+    }
+
+    #[OA\Post(
+        path: '/passkeys/register-options',
+        summary: 'Generate WebAuthn registration options',
+        security: [
+            ['sanctum' => []],
+        ],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['name'],
+                properties: [
+                    new OA\Property(property: 'name', type: 'string'),
+                ]
+            )
+        ),
+        tags: ['Passkey'],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Options generated',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: true),
+                        new OA\Property(property: 'message', type: 'string'),
+                        new OA\Property(
+                            property: 'data',
+                            properties: [
+                                new OA\Property(
+                                    property: 'options',
+                                    type: 'string',
+                                    description: 'JSON-encoded WebAuthn PublicKeyCredentialCreationOptions',
+                                    example: '{"challenge":"...","rp":{"name":"Laravel","id":"app.example.com"},...}'
+                                ),
+                                new OA\Property(
+                                    property: 'session_id',
+                                    type: 'string',
+                                    example: 'reg_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+                                ),
+                            ],
+                            type: 'object'
+                        ),
+                    ],
+                    type: 'object'
+                )
+            ),
+            new OA\Response(
+                response: 401,
+                description: 'Unauthenticated',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: false),
+                        new OA\Property(property: 'message', type: 'string'),
+                        new OA\Property(property: 'errors', type: 'array', items: new OA\Items()),
+                    ],
+                    type: 'object'
+                )
+            ),
+            new OA\Response(
+                response: 422,
+                description: 'Validation error',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: false),
+                        new OA\Property(property: 'message', type: 'string'),
+                        new OA\Property(property: 'errors', type: 'array', items: new OA\Items()),
+                    ],
+                    type: 'object'
+                )
+            ),
+        ]
+    )]
+    public function passkeyRegisterOptions()
+    {
+    }
+
+    #[OA\Post(
+        path: '/passkeys/login-options',
+        summary: 'Generate WebAuthn login options',
+        security: [],
+        requestBody: new OA\RequestBody(
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'email', type: 'string', format: 'email'),
+                ]
+            )
+        ),
+        tags: ['Passkey'],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Options generated',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: true),
+                        new OA\Property(property: 'message', type: 'string'),
+                        new OA\Property(
+                            property: 'data',
+                            properties: [
+                                new OA\Property(
+                                    property: 'options',
+                                    type: 'string',
+                                    description: 'JSON-encoded WebAuthn PublicKeyCredentialRequestOptions',
+                                    example: '{"challenge":"...","rpId":"app.example.com","allowCredentials":[...]}'
+                                ),
+                                new OA\Property(
+                                    property: 'session_id',
+                                    type: 'string',
+                                    example: 'log_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+                                ),
+                            ],
+                            type: 'object'
+                        ),
+                    ],
+                    type: 'object'
+                )
+            ),
+            new OA\Response(
+                response: 400,
+                description: 'Invalid credentials',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: false),
+                        new OA\Property(property: 'message', type: 'string'),
+                        new OA\Property(property: 'errors', type: 'array', items: new OA\Items()),
+                    ],
+                    type: 'object'
+                )
+            ),
+            new OA\Response(
+                response: 422,
+                description: 'Validation error',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: false),
+                        new OA\Property(property: 'message', type: 'string'),
+                        new OA\Property(property: 'errors', type: 'array', items: new OA\Items()),
+                    ],
+                    type: 'object'
+                )
+            ),
+        ]
+    )]
+    public function passkeyLoginOptions()
+    {
+    }
+
+    #[OA\Post(
+        path: '/passkeys/login',
+        summary: 'Authenticate using a passkey',
+        security: [],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['session_id', 'passkey'],
+                properties: [
+                    new OA\Property(property: 'session_id', type: 'string'),
+                    new OA\Property(property: 'passkey', type: 'object'),
+                ]
+            )
+        ),
+        tags: ['Passkey'],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Authenticated successfully',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: true),
+                        new OA\Property(property: 'message', type: 'string'),
+                        new OA\Property(
+                            property: 'data',
+                            properties: [
+                                new OA\Property(property: 'token', type: 'string'),
+                                new OA\Property(property: 'token_type', type: 'string', example: 'Bearer'),
+                                new OA\Property(property: 'user', type: 'object'),
+                            ],
+                            type: 'object'
+                        ),
+                    ],
+                    type: 'object'
+                )
+            ),
+            new OA\Response(
+                response: 400,
+                description: 'Invalid passkey or session',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: false),
+                        new OA\Property(property: 'message', type: 'string'),
+                        new OA\Property(property: 'errors', type: 'array', items: new OA\Items()),
+                    ],
+                    type: 'object'
+                )
+            ),
+            new OA\Response(
+                response: 422,
+                description: 'Validation error',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: false),
+                        new OA\Property(property: 'message', type: 'string'),
+                        new OA\Property(property: 'errors', type: 'array', items: new OA\Items()),
+                    ],
+                    type: 'object'
+                )
+            ),
+        ]
+    )]
+    public function passkeyLogin()
+    {
+    }
+
+    #[OA\Post(
+        path: '/passkeys/register',
+        summary: 'Register a new passkey for the authenticated user',
+        security: [
+            ['sanctum' => []],
+        ],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['name', 'session_id', 'passkey'],
+                properties: [
+                    new OA\Property(property: 'name', type: 'string'),
+                    new OA\Property(property: 'session_id', type: 'string'),
+                    new OA\Property(property: 'passkey', type: 'object'),
+                ]
+            )
+        ),
+        tags: ['Passkey'],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Passkey created',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: true),
+                        new OA\Property(property: 'message', type: 'string'),
+                        new OA\Property(property: 'data', type: 'object'),
+                    ],
+                    type: 'object'
+                )
+            ),
+            new OA\Response(
+                response: 400,
+                description: 'Invalid passkey or session',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: false),
+                        new OA\Property(property: 'message', type: 'string'),
+                        new OA\Property(property: 'errors', type: 'array', items: new OA\Items()),
+                    ],
+                    type: 'object'
+                )
+            ),
+            new OA\Response(
+                response: 401,
+                description: 'Unauthenticated',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: false),
+                        new OA\Property(property: 'message', type: 'string'),
+                        new OA\Property(property: 'errors', type: 'array', items: new OA\Items()),
+                    ],
+                    type: 'object'
+                )
+            ),
+            new OA\Response(
+                response: 422,
+                description: 'Validation error',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: false),
+                        new OA\Property(property: 'message', type: 'string'),
+                        new OA\Property(property: 'errors', type: 'array', items: new OA\Items()),
+                    ],
+                    type: 'object'
+                )
+            ),
+        ]
+    )]
+    public function passkeyRegister()
+    {
+    }
+
+    #[OA\Get(
+        path: '/passkeys',
+        summary: 'List authenticated user passkeys',
+        security: [
+            ['sanctum' => []],
+        ],
+        tags: ['Passkey'],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Passkeys retrieved',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: true),
+                        new OA\Property(property: 'message', type: 'string'),
+                        new OA\Property(
+                            property: 'data',
+                            properties: [
+                                new OA\Property(
+                                    property: 'passkeys',
+                                    type: 'array',
+                                    items: new OA\Items(
+                                        properties: [
+                                            new OA\Property(property: 'id', type: 'integer'),
+                                            new OA\Property(property: 'name', type: 'string'),
+                                            new OA\Property(property: 'credential_id', type: 'string'),
+                                            new OA\Property(
+                                                property: 'created_at',
+                                                type: 'string',
+                                                format: 'date-time'
+                                            ),
+                                            new OA\Property(
+                                                property: 'updated_at',
+                                                type: 'string',
+                                                format: 'date-time'
+                                            ),
+                                        ],
+                                        type: 'object'
+                                    )
+                                ),
+                            ],
+                            type: 'object'
+                        ),
+                    ],
+                    type: 'object'
+                )
+            ),
+            new OA\Response(
+                response: 401,
+                description: 'Unauthenticated',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: false),
+                        new OA\Property(property: 'message', type: 'string'),
+                        new OA\Property(property: 'errors', type: 'array', items: new OA\Items()),
+                    ],
+                    type: 'object'
+                )
+            ),
+        ]
+    )]
+    public function passkeyIndex()
+    {
+    }
+
+    #[OA\Delete(
+        path: '/passkeys/{passkey}',
+        summary: 'Delete a passkey',
+        security: [
+            ['sanctum' => []],
+        ],
+        tags: ['Passkey'],
+        parameters: [
+            new OA\Parameter(
+                name: 'passkey',
+                description: 'Passkey ID',
+                in: 'path',
+                required: true,
+                schema: new OA\Schema(type: 'integer')
+            ),
+        ],
+        responses: [
+            new OA\Response(response: 204, description: 'Passkey deleted'),
+            new OA\Response(
+                response: 401,
+                description: 'Unauthenticated',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: false),
+                        new OA\Property(property: 'message', type: 'string'),
+                        new OA\Property(property: 'errors', type: 'array', items: new OA\Items()),
+                    ],
+                    type: 'object'
+                )
+            ),
+            new OA\Response(
+                response: 404,
+                description: 'Passkey not found',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'success', type: 'boolean', example: false),
+                        new OA\Property(property: 'message', type: 'string'),
+                        new OA\Property(property: 'errors', type: 'array', items: new OA\Items()),
+                    ],
+                    type: 'object'
+                )
+            ),
+        ]
+    )]
+    public function passkeyDestroy()
     {
     }
 }

--- a/src/Enums/HookAction.php
+++ b/src/Enums/HookAction.php
@@ -16,6 +16,12 @@ enum HookAction: string
     case PASSWORD_RESET = 'passwordReset';
     case SEND_VERIFICATION_CODE = 'sendVerificationCode';
     case VERIFY_CODE = 'verifyCode';
+    case PASSKEY_LOGIN_OPTIONS = 'passkeyLoginOptions';
+    case PASSKEY_REGISTER_OPTIONS = 'passkeyRegisterOptions';
+    case PASSKEY_LOGIN = 'passkeyLogin';
+    case PASSKEY_REGISTER = 'passkeyRegister';
+    case PASSKEY_INDEX = 'passkeyIndex';
+    case PASSKEY_DELETE = 'passkeyDelete';
 
     /**
      * Get all predefined hook actions.

--- a/src/Http/Controllers/Auth/PasskeyController.php
+++ b/src/Http/Controllers/Auth/PasskeyController.php
@@ -1,0 +1,316 @@
+<?php
+
+namespace Whilesmart\UserAuthentication\Http\Controllers\Auth;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\AuthenticatorAssertionResponseValidator;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\AuthenticatorAttestationResponseValidator;
+use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
+use Webauthn\CredentialRecord;
+use Webauthn\Exception\InvalidDataException;
+use Webauthn\PublicKeyCredential;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\PublicKeyCredentialRpEntity;
+use Webauthn\PublicKeyCredentialUserEntity;
+use Whilesmart\UserAuthentication\Enums\HookAction;
+use Whilesmart\UserAuthentication\Events\UserLoggedInEvent;
+use Whilesmart\UserAuthentication\Http\Controllers\Controller;
+use Whilesmart\UserAuthentication\Models\Passkey;
+use Whilesmart\UserAuthentication\Rules\EmailDomainRestriction;
+use Whilesmart\UserAuthentication\Traits\ApiResponse;
+use Whilesmart\UserAuthentication\Traits\HasMiddlewareHooks;
+use Whilesmart\UserAuthentication\Traits\Loggable;
+
+class PasskeyController extends Controller
+{
+    use ApiResponse;
+    use HasMiddlewareHooks;
+    use Loggable;
+
+
+    /**
+     * @throws ExceptionInterface
+     * @throws InvalidDataException
+     */
+    public function registerOptions(Request $request): JsonResponse
+    {
+        $request = $this->runBeforeHooks($request, HookAction::PASSKEY_LOGIN_OPTIONS);
+
+        $validationRules = [
+            'name' => ['required', 'string', 'max:255']
+        ];
+        $validator = Validator::make($request->all(), $validationRules);
+
+        if ($validator->fails()) {
+            $response = $this->failure('Validation failed.', 422, [$validator->errors()]);
+            return $this->runAfterHooks($request, $response, HookAction::PASSKEY_REGISTER_OPTIONS);
+        }
+        $options = new PublicKeyCredentialCreationOptions(
+            rp: new PublicKeyCredentialRpEntity(
+                name: config('app.name'),
+                id: parse_url(config('user-authentication.passkey.domain'), PHP_URL_HOST),
+            ),
+            user: new PublicKeyCredentialUserEntity(
+                name: $request->user()->email,
+                id: $request->user()->id,
+                displayName: $request->user()->name,
+            ),
+            challenge: Str::random(),
+        );
+
+        $response = $this->success(['options' => $options]);
+        return $this->runAfterHooks($request, $response, HookAction::PASSKEY_REGISTER_OPTIONS);
+    }
+
+    /**
+     * @throws InvalidDataException
+     * @throws ExceptionInterface
+     */
+    public function loginOptions(Request $request): JsonResponse
+    {
+        $request = $this->runBeforeHooks($request, HookAction::PASSKEY_LOGIN_OPTIONS);
+
+        $validationRules = [
+            'email' => [
+                'required',
+                'string',
+                'email',
+                'max:255',
+                new EmailDomainRestriction(),
+            ],
+        ];
+        $validator = Validator::make($request->all(), $validationRules);
+
+        if ($validator->fails()) {
+            $response = $this->failure('Validation failed.', 422, [$validator->errors()]);
+            return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN_OPTIONS);
+        }
+
+        $User = config('user-authentication.user_model');
+        $user = $User::where('email', $request->email)->first();
+        if (!$user) {
+            $response = $this->failure(__('User not found'));
+            return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN_OPTIONS);
+        }
+
+        $allowedCredentials = $user->passkeys()
+            ->get()
+            ->map(fn(Passkey $passkey) => $passkey->getCredential())
+            ->map(fn(CredentialRecord $publicKeyCredentialSource) => $publicKeyCredentialSource->getPublicKeyCredentialDescriptor())
+            ->all();
+
+        $options = new PublicKeyCredentialRequestOptions(
+            challenge: Str::random(),
+            rpId: parse_url(config('user-authentication.passkey.domain'), PHP_URL_HOST),
+            allowCredentials: $allowedCredentials,
+        );
+
+        $response = $this->success(['options' => Passkey::webAuthnSerializer()->serialize($options, 'json')]);
+        return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN_OPTIONS);
+    }
+
+
+    /**
+     * @throws ValidationException
+     * @throws ExceptionInterface
+     */
+    public function login(Request $request): JsonResponse
+    {
+        $request = $this->runBeforeHooks($request, HookAction::PASSKEY_LOGIN);
+
+        $validationRules = [
+            'passkey' => ['required', 'array'],
+            'options' => ['required', 'array']
+        ];
+
+        $validator = Validator::make($request->all(), $validationRules);
+
+        if ($validator->fails()) {
+            $response = $this->failure('Validation failed.', 422, [$validator->errors()]);
+
+            return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN);
+        }
+
+        $data = $request->only(['passkey', 'options']);
+
+        $publicKeyCredential = Passkey::webAuthnSerializer()->deserialize(
+            json_encode($data['passkey']),
+            PublicKeyCredential::class,
+            'json'
+        );
+
+        $publicKeyCredentialOptions = Passkey::webAuthnSerializer()->deserialize(
+            json_encode($data['options']),
+            PublicKeyCredentialRequestOptions::class,
+            'json'
+        );
+        if (!$publicKeyCredential->response instanceof AuthenticatorAssertionResponse) {
+            // todo: unable to reproduce this particular case. Might not necessarily be an error
+            $response = $this->failure(__('This passkey is not valid'));
+            return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN);
+
+        }
+
+        $passkey = Passkey::firstWhere('credential_id', $this->base64urlEncode($publicKeyCredential->rawId));
+
+        if (!$passkey) {
+            $response = $this->failure(__('This passkey is not valid'));
+            return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN);
+        }
+
+        try {
+            $csmFactory = new CeremonyStepManagerFactory();
+            $csmFactory->setAllowedOrigins(config('user-authentication.passkey.allowed_origins'));
+            $publicKeyCredentialSource = AuthenticatorAssertionResponseValidator::create(
+                $csmFactory->requestCeremony()
+            )->check(
+                credentialRecord: $passkey->getCredential(),
+                authenticatorAssertionResponse: $publicKeyCredential->response,
+                publicKeyCredentialRequestOptions: $publicKeyCredentialOptions,
+                host: $request->getHost(),
+                userHandle: null,
+            );
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+            $response = $this->failure(__('This passkey is not valid'));
+            return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN);
+        }
+
+        $passkey->update(['data' => Passkey::webAuthnSerializer()->serialize($publicKeyCredentialSource, 'json')]);
+
+        $user = $passkey->keyable;
+
+        if (!$user) {
+            $response = $this->failure('Invalid credentials', 401);
+
+            return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN);
+        }
+        UserLoggedInEvent::dispatch($user);
+
+        $response = $this->success([
+            'token' => $user->createToken('auth-token')->plainTextToken,
+            'token_type' => 'Bearer',
+            'user' => auth()->user(),
+        ], 'User successfully logged in', 200);
+
+        return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN);
+    }
+
+    private function base64urlEncode(string $data): string
+    {
+        // 1. Run standard base64
+        $b64 = base64_encode($data);
+
+        // 2. Replace + with -, / with _, and remove = padding
+        return rtrim(strtr($b64, '+/', '-_'), '=');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     * @throws ExceptionInterface
+     */
+    public function register(Request $request): JsonResponse
+    {
+        $request = $this->runBeforeHooks($request, HookAction::PASSKEY_REGISTER);
+
+        $validationRules = [
+            'name' => ['required', 'string', 'max:255'],
+            'options' => ['required', 'array'],
+            'passkey' => ['required', 'array'],
+        ];
+
+        $validator = Validator::make($request->all(), $validationRules);
+
+        if ($validator->fails()) {
+            $response = $this->failure('Validation failed.', 422, [$validator->errors()]);
+
+            return $this->runAfterHooks($request, $response, HookAction::PASSKEY_REGISTER);
+        }
+        $data = $request->all();
+
+        $publicKeyCredential = Passkey::webAuthnSerializer()->deserialize(
+            json_encode($data['passkey']),
+            PublicKeyCredential::class,
+            'json'
+        );
+
+        $publicKeyCredentialOptions = Passkey::webAuthnSerializer()->deserialize(
+            json_encode($data['options']),
+            PublicKeyCredentialCreationOptions::class,
+            'json'
+        );
+
+
+        if (!$publicKeyCredential->response instanceof AuthenticatorAttestationResponse) {
+            // todo: unable to reproduce this particular case. Might not necessarily be an error
+            $response = $this->failure(__('This passkey is not valid'));
+            return $this->runAfterHooks($request, $response, HookAction::PASSKEY_REGISTER);
+        }
+
+        try {
+            $csmFactory = new CeremonyStepManagerFactory();
+            $csmFactory->setAllowedOrigins(config('user-authentication.passkey.allowed_origins'));
+            $publicKeyCredentialSource = AuthenticatorAttestationResponseValidator::create(
+                $csmFactory->creationCeremony(),
+            )->check(
+                authenticatorAttestationResponse: $publicKeyCredential->response,
+                publicKeyCredentialCreationOptions: $publicKeyCredentialOptions,
+                host: $request->getHost(),
+            );
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+            $response = $this->failure(__('This passkey is not valid'));
+            return $this->runAfterHooks($request, $response, HookAction::PASSKEY_REGISTER);
+        }
+
+        $user = $request->user();
+        $exists = Passkey::where('credential_id', $this->base64urlEncode($publicKeyCredentialSource->publicKeyCredentialId))
+            ->where('keyable_id', $user->id)
+            ->where('keyable_type', config('user-authentication.user_model'))
+            ->exists();
+        if ($exists) {
+            $response = $this->failure(__('This passkey already exists'));
+            return $this->runAfterHooks($request, $response, HookAction::PASSKEY_REGISTER);
+        }
+
+        $request->user()->passkeys()->create([
+            'name' => $data['name'],
+            'credential_id' => $this->base64urlEncode($publicKeyCredentialSource->publicKeyCredentialId),
+            'data' => Passkey::webAuthnSerializer()->serialize($publicKeyCredentialSource, 'json'),
+        ]);
+        $response = $this->success(message: __('Passkey created'));
+        return $this->runAfterHooks($request, $response, HookAction::PASSKEY_REGISTER);
+
+    }
+
+    public function index(Request $request): JsonResponse
+    {
+        $passkeys = $request->user()->passkeys;
+        $response = $this->success(data: ['passkeys' => $passkeys], message: __('Passkey created'));
+        return $this->runAfterHooks($request, $response, HookAction::PASSKEY_INDEX);
+
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Request $request, $passkeyId): JsonResponse
+    {
+        $passkey = $request->user()->passkeys()->find($passkeyId);
+        if (!$passkey) {
+            $response = $this->failure(__('Passkey not found'), 404);
+            return $this->runAfterHooks($request, $response, HookAction::PASSKEY_DELETE);
+        }
+        $passkey->delete();
+        $response = $this->success(statusCode: 204);
+        return $this->runAfterHooks($request, $response, HookAction::PASSKEY_DELETE);
+    }
+}

--- a/src/Http/Controllers/Auth/PasskeyController.php
+++ b/src/Http/Controllers/Auth/PasskeyController.php
@@ -4,27 +4,18 @@ namespace Whilesmart\UserAuthentication\Http\Controllers\Auth;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
-use Webauthn\AuthenticatorAssertionResponse;
-use Webauthn\AuthenticatorAssertionResponseValidator;
-use Webauthn\AuthenticatorAttestationResponse;
-use Webauthn\AuthenticatorAttestationResponseValidator;
-use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
-use Webauthn\CredentialRecord;
 use Webauthn\Exception\InvalidDataException;
-use Webauthn\PublicKeyCredential;
-use Webauthn\PublicKeyCredentialCreationOptions;
-use Webauthn\PublicKeyCredentialRequestOptions;
-use Webauthn\PublicKeyCredentialRpEntity;
-use Webauthn\PublicKeyCredentialUserEntity;
 use Whilesmart\UserAuthentication\Enums\HookAction;
 use Whilesmart\UserAuthentication\Events\UserLoggedInEvent;
 use Whilesmart\UserAuthentication\Http\Controllers\Controller;
 use Whilesmart\UserAuthentication\Models\Passkey;
 use Whilesmart\UserAuthentication\Rules\EmailDomainRestriction;
+use Whilesmart\UserAuthentication\Services\PasskeyService;
 use Whilesmart\UserAuthentication\Traits\ApiResponse;
 use Whilesmart\UserAuthentication\Traits\HasMiddlewareHooks;
 use Whilesmart\UserAuthentication\Traits\Loggable;
@@ -35,6 +26,13 @@ class PasskeyController extends Controller
     use HasMiddlewareHooks;
     use Loggable;
 
+
+    private PasskeyService $passkeyService;
+
+    public function __construct(PasskeyService $passkeyService)
+    {
+        $this->passkeyService = $passkeyService;
+    }
 
     /**
      * @throws ExceptionInterface
@@ -53,20 +51,15 @@ class PasskeyController extends Controller
             $response = $this->failure('Validation failed.', 422, [$validator->errors()]);
             return $this->runAfterHooks($request, $response, HookAction::PASSKEY_REGISTER_OPTIONS);
         }
-        $options = new PublicKeyCredentialCreationOptions(
-            rp: new PublicKeyCredentialRpEntity(
-                name: config('app.name'),
-                id: parse_url(config('user-authentication.passkey.domain'), PHP_URL_HOST),
-            ),
-            user: new PublicKeyCredentialUserEntity(
-                name: $request->user()->email,
-                id: $request->user()->id,
-                displayName: $request->user()->name,
-            ),
-            challenge: Str::random(),
-        );
 
-        $response = $this->success(['options' => $options]);
+        $user = $request->user();
+        $options = $this->passkeyService->getRegistrationOptions($user->id, $user->email, $user->name);
+
+        $options = Passkey::webAuthnSerializer()->serialize($options, 'json');
+        $sessionId = "reg_" . Str::uuid()->toString();
+        Cache::add($sessionId, $options, now()->addMinutes(config('user-authentication.passkey.session_lifetime')));
+
+        $response = $this->success(['options' => $options, 'session_id' => $sessionId]);
         return $this->runAfterHooks($request, $response, HookAction::PASSKEY_REGISTER_OPTIONS);
     }
 
@@ -101,19 +94,13 @@ class PasskeyController extends Controller
             return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN_OPTIONS);
         }
 
-        $allowedCredentials = $user->passkeys()
-            ->get()
-            ->map(fn(Passkey $passkey) => $passkey->getCredential())
-            ->map(fn(CredentialRecord $publicKeyCredentialSource) => $publicKeyCredentialSource->getPublicKeyCredentialDescriptor())
-            ->all();
+        $options = $this->passkeyService->getLoginOptions($user->id);
+        $options = Passkey::webAuthnSerializer()->serialize($options, 'json');
 
-        $options = new PublicKeyCredentialRequestOptions(
-            challenge: Str::random(),
-            rpId: parse_url(config('user-authentication.passkey.domain'), PHP_URL_HOST),
-            allowCredentials: $allowedCredentials,
-        );
+        $sessionId = "log_" . Str::uuid()->toString();
+        Cache::add($sessionId, $options, now()->addMinutes(config('user-authentication.passkey.session_lifetime')));
 
-        $response = $this->success(['options' => Passkey::webAuthnSerializer()->serialize($options, 'json')]);
+        $response = $this->success(['options' => $options, 'session_id' => $sessionId]);
         return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN_OPTIONS);
     }
 
@@ -128,7 +115,7 @@ class PasskeyController extends Controller
 
         $validationRules = [
             'passkey' => ['required', 'array'],
-            'options' => ['required', 'array']
+            'session_id' => ['required', 'string']
         ];
 
         $validator = Validator::make($request->all(), $validationRules);
@@ -139,52 +126,20 @@ class PasskeyController extends Controller
             return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN);
         }
 
-        $data = $request->only(['passkey', 'options']);
+        $data = $request->only(['passkey', 'session_id']);
 
-        $publicKeyCredential = Passkey::webAuthnSerializer()->deserialize(
-            json_encode($data['passkey']),
-            PublicKeyCredential::class,
-            'json'
+        $options = Cache::get($data['session_id']);
+        if (is_null($options)) {
+            $response = $this->failure(__('Invalid session id'));
+            return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN);
+
+        }
+
+        $passkey = $this->passkeyService->verifyPasskey(
+            $data['passkey'],
+            $options,
+            $request->getHost()
         );
-
-        $publicKeyCredentialOptions = Passkey::webAuthnSerializer()->deserialize(
-            json_encode($data['options']),
-            PublicKeyCredentialRequestOptions::class,
-            'json'
-        );
-        if (!$publicKeyCredential->response instanceof AuthenticatorAssertionResponse) {
-            // todo: unable to reproduce this particular case. Might not necessarily be an error
-            $response = $this->failure(__('This passkey is not valid'));
-            return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN);
-
-        }
-
-        $passkey = Passkey::firstWhere('credential_id', $this->base64urlEncode($publicKeyCredential->rawId));
-
-        if (!$passkey) {
-            $response = $this->failure(__('This passkey is not valid'));
-            return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN);
-        }
-
-        try {
-            $csmFactory = new CeremonyStepManagerFactory();
-            $csmFactory->setAllowedOrigins(config('user-authentication.passkey.allowed_origins'));
-            $publicKeyCredentialSource = AuthenticatorAssertionResponseValidator::create(
-                $csmFactory->requestCeremony()
-            )->check(
-                credentialRecord: $passkey->getCredential(),
-                authenticatorAssertionResponse: $publicKeyCredential->response,
-                publicKeyCredentialRequestOptions: $publicKeyCredentialOptions,
-                host: $request->getHost(),
-                userHandle: null,
-            );
-        } catch (\Throwable $e) {
-            $this->error($e->getMessage());
-            $response = $this->failure(__('This passkey is not valid'));
-            return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN);
-        }
-
-        $passkey->update(['data' => Passkey::webAuthnSerializer()->serialize($publicKeyCredentialSource, 'json')]);
 
         $user = $passkey->keyable;
 
@@ -204,18 +159,10 @@ class PasskeyController extends Controller
         return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN);
     }
 
-    private function base64urlEncode(string $data): string
-    {
-        // 1. Run standard base64
-        $b64 = base64_encode($data);
-
-        // 2. Replace + with -, / with _, and remove = padding
-        return rtrim(strtr($b64, '+/', '-_'), '=');
-    }
-
     /**
      * Store a newly created resource in storage.
      * @throws ExceptionInterface
+     * @throws \Throwable
      */
     public function register(Request $request): JsonResponse
     {
@@ -223,7 +170,7 @@ class PasskeyController extends Controller
 
         $validationRules = [
             'name' => ['required', 'string', 'max:255'],
-            'options' => ['required', 'array'],
+            'session_id' => ['required', 'string'],
             'passkey' => ['required', 'array'],
         ];
 
@@ -236,43 +183,21 @@ class PasskeyController extends Controller
         }
         $data = $request->all();
 
-        $publicKeyCredential = Passkey::webAuthnSerializer()->deserialize(
-            json_encode($data['passkey']),
-            PublicKeyCredential::class,
-            'json'
-        );
+        $options = Cache::get($data['session_id']);
+        if (is_null($options)) {
+            $response = $this->failure(__('Invalid session id'));
+            return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN);
 
-        $publicKeyCredentialOptions = Passkey::webAuthnSerializer()->deserialize(
-            json_encode($data['options']),
-            PublicKeyCredentialCreationOptions::class,
-            'json'
-        );
-
-
-        if (!$publicKeyCredential->response instanceof AuthenticatorAttestationResponse) {
-            // todo: unable to reproduce this particular case. Might not necessarily be an error
-            $response = $this->failure(__('This passkey is not valid'));
-            return $this->runAfterHooks($request, $response, HookAction::PASSKEY_REGISTER);
         }
 
-        try {
-            $csmFactory = new CeremonyStepManagerFactory();
-            $csmFactory->setAllowedOrigins(config('user-authentication.passkey.allowed_origins'));
-            $publicKeyCredentialSource = AuthenticatorAttestationResponseValidator::create(
-                $csmFactory->creationCeremony(),
-            )->check(
-                authenticatorAttestationResponse: $publicKeyCredential->response,
-                publicKeyCredentialCreationOptions: $publicKeyCredentialOptions,
-                host: $request->getHost(),
-            );
-        } catch (\Throwable $e) {
-            $this->error($e->getMessage());
-            $response = $this->failure(__('This passkey is not valid'));
-            return $this->runAfterHooks($request, $response, HookAction::PASSKEY_REGISTER);
-        }
+        $publicKeyCredentialSource = $this->passkeyService->getPublicKeyCredentialSource(
+            $data['passkey'],
+            $options,
+            $request->getHost()
+        );
 
         $user = $request->user();
-        $exists = Passkey::where('credential_id', $this->base64urlEncode($publicKeyCredentialSource->publicKeyCredentialId))
+        $exists = Passkey::where('credential_id', $this->passkeyService->getCredentialId($publicKeyCredentialSource))
             ->where('keyable_id', $user->id)
             ->where('keyable_type', config('user-authentication.user_model'))
             ->exists();
@@ -283,7 +208,7 @@ class PasskeyController extends Controller
 
         $request->user()->passkeys()->create([
             'name' => $data['name'],
-            'credential_id' => $this->base64urlEncode($publicKeyCredentialSource->publicKeyCredentialId),
+            'credential_id' => $this->passkeyService->getCredentialId($publicKeyCredentialSource),
             'data' => Passkey::webAuthnSerializer()->serialize($publicKeyCredentialSource, 'json'),
         ]);
         $response = $this->success(message: __('Passkey created'));

--- a/src/Http/Controllers/Auth/PasskeyController.php
+++ b/src/Http/Controllers/Auth/PasskeyController.php
@@ -2,6 +2,7 @@
 
 namespace Whilesmart\UserAuthentication\Http\Controllers\Auth;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
@@ -14,7 +15,6 @@ use Whilesmart\UserAuthentication\Enums\HookAction;
 use Whilesmart\UserAuthentication\Events\UserLoggedInEvent;
 use Whilesmart\UserAuthentication\Http\Controllers\Controller;
 use Whilesmart\UserAuthentication\Models\Passkey;
-use Whilesmart\UserAuthentication\Models\User;
 use Whilesmart\UserAuthentication\Rules\EmailDomainRestriction;
 use Whilesmart\UserAuthentication\Services\PasskeyService;
 use Whilesmart\UserAuthentication\Traits\ApiResponse;
@@ -41,7 +41,7 @@ class PasskeyController extends Controller
      */
     public function registerOptions(Request $request): JsonResponse
     {
-        $request = $this->runBeforeHooks($request, HookAction::PASSKEY_LOGIN_OPTIONS);
+        $request = $this->runBeforeHooks($request, HookAction::PASSKEY_REGISTER_OPTIONS);
 
         $validationRules = [
             'name' => ['required', 'string', 'max:255']
@@ -95,7 +95,7 @@ class PasskeyController extends Controller
             $User = config('user-authentication.user_model');
             $user = $User::where('email', $request->email)->first();
             if (!$user) {
-                $response = $this->failure(__('User not found'));
+                $response = $this->failure(__('Invalid credentials'));
                 return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN_OPTIONS);
             }
             $userId = $user->id;
@@ -105,7 +105,14 @@ class PasskeyController extends Controller
         $options = Passkey::webAuthnSerializer()->serialize($options, 'json');
 
         $sessionId = "log_" . Str::uuid()->toString();
-        Cache::add($sessionId, $options, now()->addMinutes(config('user-authentication.passkey.session_lifetime')));
+        Cache::add(
+            $sessionId,
+            json_encode([
+                'options' => $options,
+                'userHandle' => $userId !== null ? (string) $userId : null,
+            ]),
+            now()->addMinutes(config('user-authentication.passkey.session_lifetime'))
+        );
 
         $response = $this->success(['options' => $options, 'session_id' => $sessionId]);
         return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN_OPTIONS);
@@ -135,21 +142,30 @@ class PasskeyController extends Controller
 
         $data = $request->only(['passkey', 'session_id']);
 
-        $options = Cache::get($data['session_id']);
-        if (is_null($options)) {
+        $cached = Cache::pull($data['session_id']);
+        if (is_null($cached)) {
             $response = $this->failure(__('Invalid session id'));
             return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN);
         }
+        $cached = json_decode($cached, true);
+        $options = $cached['options'] ?? $cached;
+        $userHandle = $cached['userHandle'] ?? null;
 
-        $passkey = $this->passkeyService->verifyPasskey(
-            $data['passkey'],
-            $options,
-            $request->getHost()
-        );
+        try {
+            $passkey = $this->passkeyService->verifyPasskey(
+                $data['passkey'],
+                $options,
+                $request->getHost(),
+                $userHandle
+            );
+        } catch (\Exception $e) {
+            $response = $this->failure($e->getMessage(), 400);
+            return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN);
+        }
 
         $user = $passkey->keyable;
 
-        if (!$user instanceof User) {
+        if (!$user instanceof Authenticatable) {
             $response = $this->failure('Invalid credentials', 401);
 
             return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN);
@@ -189,22 +205,26 @@ class PasskeyController extends Controller
         }
         $data = $request->all();
 
-        $options = Cache::get($data['session_id']);
+        $options = Cache::pull($data['session_id']);
         if (is_null($options)) {
             $response = $this->failure(__('Invalid session id'));
-            return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN);
+            return $this->runAfterHooks($request, $response, HookAction::PASSKEY_REGISTER);
         }
 
-        $publicKeyCredentialSource = $this->passkeyService->getPublicKeyCredentialSource(
-            $data['passkey'],
-            $options,
-            $request->getHost()
-        );
+        try {
+            $publicKeyCredentialSource = $this->passkeyService->getPublicKeyCredentialSource(
+                $data['passkey'],
+                $options,
+                $request->getHost()
+            );
+        } catch (\Exception $e) {
+            $response = $this->failure($e->getMessage(), 400);
+            return $this->runAfterHooks($request, $response, HookAction::PASSKEY_REGISTER);
+        }
 
         $user = $request->user();
-        $exists = Passkey::where('credential_id', $this->passkeyService->getCredentialId($publicKeyCredentialSource))
-            ->where('keyable_id', $user->id)
-            ->where('keyable_type', config('user-authentication.user_model'))
+        $exists = $user->passkeys()
+            ->where('credential_id', $this->passkeyService->getCredentialId($publicKeyCredentialSource))
             ->exists();
         if ($exists) {
             $response = $this->failure(__('This passkey already exists'));
@@ -222,8 +242,11 @@ class PasskeyController extends Controller
 
     public function index(Request $request): JsonResponse
     {
-        $passkeys = $request->user()->passkeys;
-        $response = $this->success(data: ['passkeys' => $passkeys], message: __('Passkey created'));
+        $request = $this->runBeforeHooks($request, HookAction::PASSKEY_INDEX);
+
+        $passkeys = $request->user()->passkeys
+            ->makeHidden(['data', 'keyable_type', 'keyable_id']);
+        $response = $this->success(data: ['passkeys' => $passkeys], message: __('Passkeys retrieved'));
         return $this->runAfterHooks($request, $response, HookAction::PASSKEY_INDEX);
     }
 
@@ -232,6 +255,8 @@ class PasskeyController extends Controller
      */
     public function destroy(Request $request, $passkeyId): JsonResponse
     {
+        $request = $this->runBeforeHooks($request, HookAction::PASSKEY_DELETE);
+
         $passkey = $request->user()->passkeys()->find($passkeyId);
         if (!$passkey) {
             $response = $this->failure(__('Passkey not found'), 404);

--- a/src/Http/Controllers/Auth/PasskeyController.php
+++ b/src/Http/Controllers/Auth/PasskeyController.php
@@ -14,6 +14,7 @@ use Whilesmart\UserAuthentication\Enums\HookAction;
 use Whilesmart\UserAuthentication\Events\UserLoggedInEvent;
 use Whilesmart\UserAuthentication\Http\Controllers\Controller;
 use Whilesmart\UserAuthentication\Models\Passkey;
+use Whilesmart\UserAuthentication\Models\User;
 use Whilesmart\UserAuthentication\Rules\EmailDomainRestriction;
 use Whilesmart\UserAuthentication\Services\PasskeyService;
 use Whilesmart\UserAuthentication\Traits\ApiResponse;
@@ -53,7 +54,9 @@ class PasskeyController extends Controller
         }
 
         $user = $request->user();
-        $options = $this->passkeyService->getRegistrationOptions($user->id, $user->email, $user->name);
+        $name = trim(($user->first_name ?? '') . ' ' . ($user->last_name ?? ''));
+        $displayName = $name ?: $user->email;
+        $options = $this->passkeyService->getRegistrationOptions((string) $user->id, $user->email, $displayName);
 
         $options = Passkey::webAuthnSerializer()->serialize($options, 'json');
         $sessionId = "reg_" . Str::uuid()->toString();
@@ -73,7 +76,7 @@ class PasskeyController extends Controller
 
         $validationRules = [
             'email' => [
-                'required',
+                'sometimes',
                 'string',
                 'email',
                 'max:255',
@@ -87,14 +90,18 @@ class PasskeyController extends Controller
             return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN_OPTIONS);
         }
 
-        $User = config('user-authentication.user_model');
-        $user = $User::where('email', $request->email)->first();
-        if (!$user) {
-            $response = $this->failure(__('User not found'));
-            return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN_OPTIONS);
+        $userId = null;
+        if ($request->has('email')) {
+            $User = config('user-authentication.user_model');
+            $user = $User::where('email', $request->email)->first();
+            if (!$user) {
+                $response = $this->failure(__('User not found'));
+                return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN_OPTIONS);
+            }
+            $userId = $user->id;
         }
 
-        $options = $this->passkeyService->getLoginOptions($user->id);
+        $options = $this->passkeyService->getLoginOptions($userId);
         $options = Passkey::webAuthnSerializer()->serialize($options, 'json');
 
         $sessionId = "log_" . Str::uuid()->toString();
@@ -132,7 +139,6 @@ class PasskeyController extends Controller
         if (is_null($options)) {
             $response = $this->failure(__('Invalid session id'));
             return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN);
-
         }
 
         $passkey = $this->passkeyService->verifyPasskey(
@@ -143,7 +149,7 @@ class PasskeyController extends Controller
 
         $user = $passkey->keyable;
 
-        if (!$user) {
+        if (!$user instanceof User) {
             $response = $this->failure('Invalid credentials', 401);
 
             return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN);
@@ -153,7 +159,7 @@ class PasskeyController extends Controller
         $response = $this->success([
             'token' => $user->createToken('auth-token')->plainTextToken,
             'token_type' => 'Bearer',
-            'user' => auth()->user(),
+            'user' => $user,
         ], 'User successfully logged in', 200);
 
         return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN);
@@ -187,7 +193,6 @@ class PasskeyController extends Controller
         if (is_null($options)) {
             $response = $this->failure(__('Invalid session id'));
             return $this->runAfterHooks($request, $response, HookAction::PASSKEY_LOGIN);
-
         }
 
         $publicKeyCredentialSource = $this->passkeyService->getPublicKeyCredentialSource(
@@ -213,7 +218,6 @@ class PasskeyController extends Controller
         ]);
         $response = $this->success(message: __('Passkey created'));
         return $this->runAfterHooks($request, $response, HookAction::PASSKEY_REGISTER);
-
     }
 
     public function index(Request $request): JsonResponse
@@ -221,7 +225,6 @@ class PasskeyController extends Controller
         $passkeys = $request->user()->passkeys;
         $response = $this->success(data: ['passkeys' => $passkeys], message: __('Passkey created'));
         return $this->runAfterHooks($request, $response, HookAction::PASSKEY_INDEX);
-
     }
 
     /**

--- a/src/Models/Passkey.php
+++ b/src/Models/Passkey.php
@@ -21,6 +21,10 @@ class Passkey extends Model
 {
     use HasFactory;
 
+    protected static ?SerializerInterface $webAuthnSerializer = null;
+
+    protected static ?AttestationStatementSupportManager $attestationStatementSupportManager = null;
+
     protected $fillable = [
         'name',
         'credential_id',
@@ -46,17 +50,30 @@ class Passkey extends Model
 
     public static function webAuthnSerializer(): SerializerInterface
     {
-        $attestationStatementSupportManager = new AttestationStatementSupportManager();
-        $attestationStatementSupportManager->add(new NoneAttestationStatementSupport());
-        $attestations = config('user-authentication.passkey.attestations');
-        if (in_array('packed', $attestations, true)) {
-            $manager = new Manager();
-            $attestationStatementSupportManager->add(new PackedAttestationStatementSupport($manager));
-        }
-        if (in_array('fido', $attestations, true)) {
-            $attestationStatementSupportManager->add(new FidoU2FAttestationStatementSupport());
+        if (self::$webAuthnSerializer === null) {
+            self::$webAuthnSerializer = (new WebauthnSerializerFactory(
+                self::attestationStatementSupportManager()
+            ))->create();
         }
 
-        return (new WebauthnSerializerFactory($attestationStatementSupportManager))->create();
+        return self::$webAuthnSerializer;
+    }
+
+    public static function attestationStatementSupportManager(): AttestationStatementSupportManager
+    {
+        if (self::$attestationStatementSupportManager === null) {
+            $manager = new AttestationStatementSupportManager();
+            $manager->add(new NoneAttestationStatementSupport());
+            $attestations = config('user-authentication.passkey.attestations');
+            if (in_array('packed', $attestations, true)) {
+                $manager->add(new PackedAttestationStatementSupport(new Manager()));
+            }
+            if (in_array('fido', $attestations, true)) {
+                $manager->add(new FidoU2FAttestationStatementSupport());
+            }
+            self::$attestationStatementSupportManager = $manager;
+        }
+
+        return self::$attestationStatementSupportManager;
     }
 }

--- a/src/Models/Passkey.php
+++ b/src/Models/Passkey.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Whilesmart\UserAuthentication\Models;
+
+use Cose\Algorithm\Manager;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Symfony\Component\Serializer\SerializerInterface;
+use Webauthn\AttestationStatement\AttestationStatementSupportManager;
+use Webauthn\AttestationStatement\FidoU2FAttestationStatementSupport;
+use Webauthn\AttestationStatement\NoneAttestationStatementSupport;
+use Webauthn\AttestationStatement\PackedAttestationStatementSupport;
+use Webauthn\CredentialRecord;
+use Webauthn\Denormalizer\WebauthnSerializerFactory;
+
+class Passkey extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'credential_id',
+        'data',
+        'user_id',
+        'keyable_type',
+        'keyable_id',
+    ];
+
+    public function keyable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function getCredential(): CredentialRecord
+    {
+
+        return $this->webAuthnSerializer()->deserialize(
+            $this->data,
+            CredentialRecord::class,
+            'json'
+        );
+
+    }
+
+    public static function webAuthnSerializer(): SerializerInterface
+    {
+        $attestationStatementSupportManager = new AttestationStatementSupportManager();
+        $attestationStatementSupportManager->add(new NoneAttestationStatementSupport()); // none is the recommended default
+        $serializers = config('user-authentication.passkey.serializers');
+        if (in_array('packed', $serializers, true)) {
+            $manager = new Manager();
+            $attestationStatementSupportManager->add(new PackedAttestationStatementSupport($manager));
+        }
+        if (in_array('fido', $serializers, true)) {
+            $attestationStatementSupportManager->add(new FidoU2FAttestationStatementSupport());
+        }
+
+        return (new WebauthnSerializerFactory($attestationStatementSupportManager))->create();
+    }
+}

--- a/src/Models/Passkey.php
+++ b/src/Models/Passkey.php
@@ -14,6 +14,9 @@ use Webauthn\AttestationStatement\PackedAttestationStatementSupport;
 use Webauthn\CredentialRecord;
 use Webauthn\Denormalizer\WebauthnSerializerFactory;
 
+/**
+ * @property string $data
+ */
 class Passkey extends Model
 {
     use HasFactory;
@@ -22,7 +25,6 @@ class Passkey extends Model
         'name',
         'credential_id',
         'data',
-        'user_id',
         'keyable_type',
         'keyable_id',
     ];
@@ -40,19 +42,18 @@ class Passkey extends Model
             CredentialRecord::class,
             'json'
         );
-
     }
 
     public static function webAuthnSerializer(): SerializerInterface
     {
         $attestationStatementSupportManager = new AttestationStatementSupportManager();
-        $attestationStatementSupportManager->add(new NoneAttestationStatementSupport()); // none is the recommended default
-        $serializers = config('user-authentication.passkey.serializers');
-        if (in_array('packed', $serializers, true)) {
+        $attestationStatementSupportManager->add(new NoneAttestationStatementSupport());
+        $attestations = config('user-authentication.passkey.attestations');
+        if (in_array('packed', $attestations, true)) {
             $manager = new Manager();
             $attestationStatementSupportManager->add(new PackedAttestationStatementSupport($manager));
         }
-        if (in_array('fido', $serializers, true)) {
+        if (in_array('fido', $attestations, true)) {
             $attestationStatementSupportManager->add(new FidoU2FAttestationStatementSupport());
         }
 

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -7,12 +7,14 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
+use Whilesmart\UserAuthentication\Traits\HasPasskeys;
 
 class User extends Authenticatable
 {
     use HasApiTokens;
     use HasFactory;
     use Notifiable;
+    use HasPasskeys;
 
     /**
      * The attributes that are mass assignable.

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -9,6 +9,16 @@ use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 use Whilesmart\UserAuthentication\Traits\HasPasskeys;
 
+/**
+ * @property int $id
+ * @property string $email
+ * @property string $password
+ * @property string|null $first_name
+ * @property string|null $last_name
+ * @property string|null $username
+ * @property string|null $phone
+ * @property \Illuminate\Support\Carbon|null $email_verified_at
+ */
 class User extends Authenticatable
 {
     use HasApiTokens;

--- a/src/Services/PasskeyService.php
+++ b/src/Services/PasskeyService.php
@@ -9,6 +9,7 @@ use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAssertionResponseValidator;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\AuthenticatorAttestationResponseValidator;
+use Webauthn\AuthenticatorSelectionCriteria;
 use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
 use Webauthn\CredentialRecord;
 use Webauthn\Exception\InvalidDataException;
@@ -24,33 +25,53 @@ class PasskeyService
 {
     use Loggable;
 
+    private function getRpId(): ?string
+    {
+        $domain = config('user-authentication.passkey.domain');
+        $host = parse_url($domain, PHP_URL_HOST);
+        if ($host !== null) {
+            return $host;
+        }
+        // If no scheme was provided, PHP's parse_url treats the value as a path.
+        // Prepend a scheme so it can be parsed as a host.
+        $host = parse_url('https://' . $domain, PHP_URL_HOST);
+        return $host;
+    }
+
     /**
      * @throws InvalidDataException
      */
-    public function getLoginOptions(int $userId): PublicKeyCredentialRequestOptions
+    public function getLoginOptions(?int $userId = null): PublicKeyCredentialRequestOptions
     {
-        $allowedCredentials = Passkey::where('user_id', $userId)
-            ->get()
-            ->map(fn(Passkey $passkey) => $passkey->getCredential())
-            ->map(fn(CredentialRecord $publicKeyCredentialSource) => $publicKeyCredentialSource->getPublicKeyCredentialDescriptor())
-            ->all();
+        if ($userId !== null) {
+            $User = config('user-authentication.user_model');
+            $allowedCredentials = Passkey::where('keyable_id', $userId)
+                ->where('keyable_type', $User)
+                ->get()
+                ->map(fn (Passkey $passkey) => $passkey->getCredential())
+                ->map(fn (CredentialRecord $source) => $source->getPublicKeyCredentialDescriptor())
+                ->all();
+        }
 
         return new PublicKeyCredentialRequestOptions(
             challenge: Str::random(),
-            rpId: parse_url(config('app.url'), PHP_URL_HOST),
-            allowCredentials: $allowedCredentials,
+            rpId: $this->getRpId(),
+            allowCredentials: $allowedCredentials ?? [],
         );
     }
 
     /**
      * @throws InvalidDataException
      */
-    public function getRegistrationOptions(string $userId, string $userEmail, string $displayName): PublicKeyCredentialCreationOptions
-    {
+    public function getRegistrationOptions(
+        string $userId,
+        string $userEmail,
+        string $displayName
+    ): PublicKeyCredentialCreationOptions {
         return new PublicKeyCredentialCreationOptions(
             rp: new PublicKeyCredentialRpEntity(
                 name: config('app.name'),
-                id: parse_url(config('user-authentication.passkey.domain'), PHP_URL_HOST),
+                id: $this->getRpId(),
             ),
             user: new PublicKeyCredentialUserEntity(
                 name: $userEmail,
@@ -58,6 +79,12 @@ class PasskeyService
                 displayName: $displayName,
             ),
             challenge: Str::random(),
+            authenticatorSelection: new AuthenticatorSelectionCriteria(
+                residentKey: config('user-authentication.passkey.resident_keys')
+                    ? AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_REQUIRED
+                    : AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_NO_PREFERENCE,
+                userVerification: AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_PREFERRED,
+            ),
         );
     }
 
@@ -101,7 +128,7 @@ class PasskeyService
             );
         } catch (\Throwable $e) {
             $this->error($e->getMessage());
-            throw new Exception(__('This passkey is not valid'), 400);
+            throw new Exception($e->getMessage(), 400);
         }
 
         $validatedPasskey->update(['data' => Passkey::webAuthnSerializer()
@@ -144,15 +171,20 @@ class PasskeyService
         }
 
 
-        $csmFactory = new CeremonyStepManagerFactory();
-        $csmFactory->setAllowedOrigins(config('user-authentication.passkey.allowed_origins'));
-        $publicKeyCredentialSource = AuthenticatorAttestationResponseValidator::create(
-            $csmFactory->creationCeremony(),
-        )->check(
-            authenticatorAttestationResponse: $publicKeyCredential->response,
-            publicKeyCredentialCreationOptions: $publicKeyCredentialOptions,
-            host: $host,
-        );
+        try {
+            $csmFactory = new CeremonyStepManagerFactory();
+            $csmFactory->setAllowedOrigins(config('user-authentication.passkey.allowed_origins'));
+            $publicKeyCredentialSource = AuthenticatorAttestationResponseValidator::create(
+                $csmFactory->creationCeremony(),
+            )->check(
+                authenticatorAttestationResponse: $publicKeyCredential->response,
+                publicKeyCredentialCreationOptions: $publicKeyCredentialOptions,
+                host: $host,
+            );
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+            throw new Exception($e->getMessage(), 400);
+        }
 
         return $publicKeyCredentialSource;
     }

--- a/src/Services/PasskeyService.php
+++ b/src/Services/PasskeyService.php
@@ -41,16 +41,17 @@ class PasskeyService
     /**
      * @throws InvalidDataException
      */
-    public function getLoginOptions(?int $userId = null): PublicKeyCredentialRequestOptions
+    public function getLoginOptions(int|string|null $userId = null): PublicKeyCredentialRequestOptions
     {
         if ($userId !== null) {
             $User = config('user-authentication.user_model');
-            $allowedCredentials = Passkey::where('keyable_id', $userId)
-                ->where('keyable_type', $User)
-                ->get()
-                ->map(fn (Passkey $passkey) => $passkey->getCredential())
-                ->map(fn (CredentialRecord $source) => $source->getPublicKeyCredentialDescriptor())
-                ->all();
+            $user = $User::find($userId);
+            $allowedCredentials = $user
+                ? $user->passkeys
+                    ->map(fn (Passkey $passkey) => $passkey->getCredential())
+                    ->map(fn (CredentialRecord $source) => $source->getPublicKeyCredentialDescriptor())
+                    ->all()
+                : [];
         }
 
         return new PublicKeyCredentialRequestOptions(
@@ -91,7 +92,7 @@ class PasskeyService
     /**
      * @throws ExceptionInterface
      */
-    public function verifyPasskey(array $passkey, string $options, string $host): Passkey
+    public function verifyPasskey(array $passkey, string $options, string $host, ?string $userHandle = null): Passkey
     {
         $publicKeyCredential = Passkey::webAuthnSerializer()->deserialize(
             json_encode($passkey),
@@ -105,7 +106,7 @@ class PasskeyService
             'json'
         );
         if (!$publicKeyCredential->response instanceof AuthenticatorAssertionResponse) {
-            throw new Exception(__('This passkey is not valid 2'), 400);
+            throw new Exception(__('This passkey is not valid'), 400);
         }
 
         $validatedPasskey = Passkey::firstWhere('credential_id', $this->base64urlEncode($publicKeyCredential->rawId));
@@ -117,6 +118,7 @@ class PasskeyService
         try {
             $csmFactory = new CeremonyStepManagerFactory();
             $csmFactory->setAllowedOrigins(config('user-authentication.passkey.allowed_origins'));
+            $csmFactory->setAttestationStatementSupportManager(Passkey::attestationStatementSupportManager());
             $publicKeyCredentialSource = AuthenticatorAssertionResponseValidator::create(
                 $csmFactory->requestCeremony()
             )->check(
@@ -124,7 +126,7 @@ class PasskeyService
                 authenticatorAssertionResponse: $publicKeyCredential->response,
                 publicKeyCredentialRequestOptions: $publicKeyCredentialOptions,
                 host: $host,
-                userHandle: null,
+                userHandle: $userHandle,
             );
         } catch (\Throwable $e) {
             $this->error($e->getMessage());
@@ -167,13 +169,14 @@ class PasskeyService
 
 
         if (!$publicKeyCredential->response instanceof AuthenticatorAttestationResponse) {
-            throw new Exception(__('This passkey is not valid 2'), 400);
+            throw new Exception(__('This passkey is not valid'), 400);
         }
 
 
         try {
             $csmFactory = new CeremonyStepManagerFactory();
             $csmFactory->setAllowedOrigins(config('user-authentication.passkey.allowed_origins'));
+            $csmFactory->setAttestationStatementSupportManager(Passkey::attestationStatementSupportManager());
             $publicKeyCredentialSource = AuthenticatorAttestationResponseValidator::create(
                 $csmFactory->creationCeremony(),
             )->check(

--- a/src/Services/PasskeyService.php
+++ b/src/Services/PasskeyService.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Whilesmart\UserAuthentication\Services;
+
+use Exception;
+use Illuminate\Support\Str;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\AuthenticatorAssertionResponseValidator;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\AuthenticatorAttestationResponseValidator;
+use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
+use Webauthn\CredentialRecord;
+use Webauthn\Exception\InvalidDataException;
+use Webauthn\PublicKeyCredential;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\PublicKeyCredentialRpEntity;
+use Webauthn\PublicKeyCredentialUserEntity;
+use Whilesmart\UserAuthentication\Models\Passkey;
+use Whilesmart\UserAuthentication\Traits\Loggable;
+
+class PasskeyService
+{
+    use Loggable;
+
+    /**
+     * @throws InvalidDataException
+     */
+    public function getLoginOptions(int $userId): PublicKeyCredentialRequestOptions
+    {
+        $allowedCredentials = Passkey::where('user_id', $userId)
+            ->get()
+            ->map(fn(Passkey $passkey) => $passkey->getCredential())
+            ->map(fn(CredentialRecord $publicKeyCredentialSource) => $publicKeyCredentialSource->getPublicKeyCredentialDescriptor())
+            ->all();
+
+        return new PublicKeyCredentialRequestOptions(
+            challenge: Str::random(),
+            rpId: parse_url(config('app.url'), PHP_URL_HOST),
+            allowCredentials: $allowedCredentials,
+        );
+    }
+
+    /**
+     * @throws InvalidDataException
+     */
+    public function getRegistrationOptions(string $userId, string $userEmail, string $displayName): PublicKeyCredentialCreationOptions
+    {
+        return new PublicKeyCredentialCreationOptions(
+            rp: new PublicKeyCredentialRpEntity(
+                name: config('app.name'),
+                id: parse_url(config('user-authentication.passkey.domain'), PHP_URL_HOST),
+            ),
+            user: new PublicKeyCredentialUserEntity(
+                name: $userEmail,
+                id: $userId,
+                displayName: $displayName,
+            ),
+            challenge: Str::random(),
+        );
+    }
+
+    /**
+     * @throws ExceptionInterface
+     */
+    public function verifyPasskey(array $passkey, string $options, string $host): Passkey
+    {
+        $publicKeyCredential = Passkey::webAuthnSerializer()->deserialize(
+            json_encode($passkey),
+            PublicKeyCredential::class,
+            'json'
+        );
+
+        $publicKeyCredentialOptions = Passkey::webAuthnSerializer()->deserialize(
+            $options,
+            PublicKeyCredentialRequestOptions::class,
+            'json'
+        );
+        if (!$publicKeyCredential->response instanceof AuthenticatorAssertionResponse) {
+            throw new Exception(__('This passkey is not valid 2'), 400);
+        }
+
+        $validatedPasskey = Passkey::firstWhere('credential_id', $this->base64urlEncode($publicKeyCredential->rawId));
+
+        if (!$validatedPasskey) {
+            throw new Exception(__('This passkey is not valid'), 400);
+        }
+
+        try {
+            $csmFactory = new CeremonyStepManagerFactory();
+            $csmFactory->setAllowedOrigins(config('user-authentication.passkey.allowed_origins'));
+            $publicKeyCredentialSource = AuthenticatorAssertionResponseValidator::create(
+                $csmFactory->requestCeremony()
+            )->check(
+                credentialRecord: $validatedPasskey->getCredential(),
+                authenticatorAssertionResponse: $publicKeyCredential->response,
+                publicKeyCredentialRequestOptions: $publicKeyCredentialOptions,
+                host: $host,
+                userHandle: null,
+            );
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+            throw new Exception(__('This passkey is not valid'), 400);
+        }
+
+        $validatedPasskey->update(['data' => Passkey::webAuthnSerializer()
+            ->serialize($publicKeyCredentialSource, 'json')]);
+        return $validatedPasskey;
+    }
+
+    private function base64urlEncode(string $data): string
+    {
+        // 1. Run standard base64
+        $b64 = base64_encode($data);
+
+        // 2. Replace + with -, / with _, and remove = padding
+        return rtrim(strtr($b64, '+/', '-_'), '=');
+    }
+
+    /**
+     * @throws ExceptionInterface
+     * @throws \Throwable
+     * @throws Exception
+     */
+    public function getPublicKeyCredentialSource(array $passkey, string $options, $host): CredentialRecord
+    {
+
+        $publicKeyCredential = Passkey::webAuthnSerializer()->deserialize(
+            json_encode($passkey),
+            PublicKeyCredential::class,
+            'json'
+        );
+
+        $publicKeyCredentialOptions = Passkey::webAuthnSerializer()->deserialize(
+            $options,
+            PublicKeyCredentialCreationOptions::class,
+            'json'
+        );
+
+
+        if (!$publicKeyCredential->response instanceof AuthenticatorAttestationResponse) {
+            throw new Exception(__('This passkey is not valid 2'), 400);
+        }
+
+
+        $csmFactory = new CeremonyStepManagerFactory();
+        $csmFactory->setAllowedOrigins(config('user-authentication.passkey.allowed_origins'));
+        $publicKeyCredentialSource = AuthenticatorAttestationResponseValidator::create(
+            $csmFactory->creationCeremony(),
+        )->check(
+            authenticatorAttestationResponse: $publicKeyCredential->response,
+            publicKeyCredentialCreationOptions: $publicKeyCredentialOptions,
+            host: $host,
+        );
+
+        return $publicKeyCredentialSource;
+    }
+
+    public function getCredentialId(CredentialRecord $publicKeyCredentialSource): string
+    {
+        return $this->base64urlEncode($publicKeyCredentialSource->publicKeyCredentialId);
+    }
+}

--- a/src/Traits/HasPasskeys.php
+++ b/src/Traits/HasPasskeys.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Whilesmart\UserAuthentication\Traits;
+
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Whilesmart\UserAuthentication\Models\Passkey;
+
+trait HasPasskeys
+{
+    public function passkeys(): MorphMany
+    {
+        return $this->morphMany(Passkey::class, 'keyable');
+    }
+}

--- a/tests/Feature/PasskeyTest.php
+++ b/tests/Feature/PasskeyTest.php
@@ -1,0 +1,272 @@
+<?php
+
+namespace Whilesmart\UserAuthentication\Tests\Feature;
+
+use Illuminate\Support\Facades\Cache;
+use Symfony\Component\Uid\Uuid;
+use Webauthn\CredentialRecord;
+use Webauthn\TrustPath\EmptyTrustPath;
+use Whilesmart\UserAuthentication\Models\Passkey;
+use Whilesmart\UserAuthentication\Services\PasskeyService;
+use Whilesmart\UserAuthentication\Tests\TestCase;
+
+class PasskeyTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('user-authentication.passkey.domain', 'https://localhost');
+        config()->set('user-authentication.passkey.allowed_origins', ['https://localhost']);
+        config()->set('user-authentication.passkey.resident_keys', true);
+    }
+
+    public function test_authenticated_user_can_get_passkey_registration_options()
+    {
+        $user = $this->createUser();
+        $token = $user->createToken('test')->plainTextToken;
+
+        $response = $this->postJson('/api/passkeys/register/options', [
+            'name' => 'Test Passkey',
+        ], ['Authorization' => 'Bearer ' . $token]);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'success',
+                'data' => ['options', 'session_id'],
+            ]);
+
+        $options = json_decode($response->json('data.options'), true);
+        $this->assertArrayHasKey('challenge', $options);
+        $this->assertSame('localhost', $options['rp']['id']);
+        $this->assertSame('John Doe', $options['user']['displayName']);
+    }
+
+    public function test_passkey_registration_fails_without_name()
+    {
+        $user = $this->createUser();
+        $token = $user->createToken('test')->plainTextToken;
+
+        $response = $this->postJson('/api/passkeys/register/options', [], [
+            'Authorization' => 'Bearer ' . $token,
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonPath('success', false)
+            ->assertJsonPath('errors.0.name', ['The name field is required.']);
+    }
+
+    public function test_authenticated_user_can_register_a_passkey()
+    {
+        $user = $this->createUser();
+        $token = $user->createToken('test')->plainTextToken;
+
+        $service = $this->app->instance(PasskeyService::class, new class () extends PasskeyService {
+            public function getPublicKeyCredentialSource(array $passkey, string $options, $host): CredentialRecord
+            {
+                return new CredentialRecord(
+                    publicKeyCredentialId: base64_decode('MTIzNA=='),
+                    type: 'public-key',
+                    transports: ['internal'],
+                    attestationType: 'none',
+                    trustPath: new EmptyTrustPath(),
+                    aaguid: Uuid::fromString('00000000-0000-0000-0000-000000000000'),
+                    credentialPublicKey: 'public-key',
+                    userHandle: (string) 1,
+                    counter: 0,
+                );
+            }
+        });
+
+        $sessionId = 'reg_' . uniqid();
+        Cache::put($sessionId, json_encode(['challenge' => 'test']), now()->addMinutes(5));
+
+        $response = $this->postJson('/api/passkeys/register', [
+            'name' => 'Test Passkey',
+            'session_id' => $sessionId,
+            'passkey' => [
+                'id' => 'dGVzdA',
+                'rawId' => 'dGVzdA',
+                'type' => 'public-key',
+                'response' => [
+                    'clientDataJSON' => 'eyJ0ZXN0IjogdHJ1ZX0',
+                    'attestationObject' => 'o2NmbXRkbm9uZQ',
+                    'transports' => ['internal'],
+                ],
+            ],
+        ], ['Authorization' => 'Bearer ' . $token]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('success', true);
+
+        $this->assertDatabaseHas('passkeys', [
+            'keyable_id' => $user->id,
+            'keyable_type' => get_class($user),
+            'name' => 'Test Passkey',
+        ]);
+    }
+
+    public function test_passkey_registration_rejects_invalid_session()
+    {
+        $user = $this->createUser();
+        $token = $user->createToken('test')->plainTextToken;
+
+        $response = $this->postJson('/api/passkeys/register', [
+            'name' => 'Test Passkey',
+            'session_id' => 'reg_invalid',
+            'passkey' => ['id' => 'x'],
+        ], ['Authorization' => 'Bearer ' . $token]);
+
+        $response->assertStatus(400)
+            ->assertJsonPath('success', false);
+    }
+
+    public function test_user_can_get_email_based_login_options()
+    {
+        $user = $this->createUser();
+        $passkey = $this->createPasskey($user);
+
+        $response = $this->postJson('/api/passkeys/login/options', [
+            'email' => $user->email,
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure(['success', 'data' => ['options', 'session_id']]);
+
+        $options = json_decode($response->json('data.options'), true);
+        $this->assertCount(1, $options['allowCredentials']);
+    }
+
+    public function test_unknown_email_returns_user_not_found()
+    {
+        $response = $this->postJson('/api/passkeys/login/options', [
+            'email' => 'missing@example.com',
+        ]);
+
+        $response->assertStatus(400)
+            ->assertJsonPath('success', false);
+    }
+
+    public function test_passwordless_login_options_return_empty_allow_credentials()
+    {
+        $response = $this->postJson('/api/passkeys/login/options', []);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure(['success', 'data' => ['options', 'session_id']]);
+
+        $options = json_decode($response->json('data.options'), true);
+        $this->assertSame([], $options['allowCredentials']);
+    }
+
+    public function test_user_can_login_with_passkey()
+    {
+        $user = $this->createUser();
+        $passkey = $this->createPasskey($user);
+
+        $this->app->instance(PasskeyService::class, new class ($passkey) extends PasskeyService {
+            public function __construct(private Passkey $passkey)
+            {
+            }
+
+            public function verifyPasskey(array $passkey, string $options, string $host): Passkey
+            {
+                return $this->passkey;
+            }
+        });
+
+        $sessionId = 'log_' . uniqid();
+        Cache::put($sessionId, json_encode(['challenge' => 'test']), now()->addMinutes(5));
+
+        $response = $this->postJson('/api/passkeys/login', [
+            'session_id' => $sessionId,
+            'passkey' => [
+                'id' => 'dGVzdA',
+                'rawId' => 'dGVzdA',
+                'type' => 'public-key',
+                'response' => [
+                    'clientDataJSON' => 'eyJ0ZXN0IjogdHJ1ZX0',
+                    'authenticatorData' => 'eyJ0ZXN0IjogdHJ1ZX0',
+                    'signature' => 'c2ln',
+                    'userHandle' => 'MQ==',
+                ],
+            ],
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure(['success', 'data' => ['token', 'user']]);
+    }
+
+    public function test_passkey_login_rejects_invalid_session()
+    {
+        $response = $this->postJson('/api/passkeys/login', [
+            'session_id' => 'log_invalid',
+            'passkey' => ['id' => 'x'],
+        ]);
+
+        $response->assertStatus(400)
+            ->assertJsonPath('success', false);
+    }
+
+    public function test_authenticated_user_can_list_passkeys()
+    {
+        $user = $this->createUser();
+        $this->createPasskey($user);
+        $token = $user->createToken('test')->plainTextToken;
+
+        $response = $this->getJson('/api/passkeys', [
+            'Authorization' => 'Bearer ' . $token,
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonCount(1, 'data.passkeys');
+    }
+
+    public function test_authenticated_user_can_delete_passkey()
+    {
+        $user = $this->createUser();
+        $passkey = $this->createPasskey($user);
+        $token = $user->createToken('test')->plainTextToken;
+
+        $response = $this->deleteJson('/api/passkeys/' . $passkey->id, [], [
+            'Authorization' => 'Bearer ' . $token,
+        ]);
+
+        $response->assertStatus(204);
+        $this->assertDatabaseMissing('passkeys', ['id' => $passkey->id]);
+    }
+
+    public function test_deleting_unknown_passkey_returns_404()
+    {
+        $user = $this->createUser();
+        $token = $user->createToken('test')->plainTextToken;
+
+        $response = $this->deleteJson('/api/passkeys/99999', [], [
+            'Authorization' => 'Bearer ' . $token,
+        ]);
+
+        $response->assertStatus(404);
+    }
+
+    private function createPasskey($user): Passkey
+    {
+        $record = new CredentialRecord(
+            publicKeyCredentialId: 'test-id',
+            type: 'public-key',
+            transports: ['internal'],
+            attestationType: 'none',
+            trustPath: new EmptyTrustPath(),
+            aaguid: Uuid::fromString('00000000-0000-0000-0000-000000000000'),
+            credentialPublicKey: 'key',
+            userHandle: (string) $user->id,
+            counter: 0,
+        );
+
+        $data = Passkey::webAuthnSerializer()->serialize($record, 'json');
+
+        return $user->passkeys()->create([
+            'name' => 'Test Passkey',
+            'credential_id' => 'dGVzdA',
+            'data' => $data,
+        ]);
+    }
+}

--- a/tests/Feature/PasskeyTest.php
+++ b/tests/Feature/PasskeyTest.php
@@ -61,7 +61,7 @@ class PasskeyTest extends TestCase
         $user = $this->createUser();
         $token = $user->createToken('test')->plainTextToken;
 
-        $service = $this->app->instance(PasskeyService::class, new class () extends PasskeyService {
+        $this->app->instance(PasskeyService::class, new class () extends PasskeyService {
             public function getPublicKeyCredentialSource(array $passkey, string $options, $host): CredentialRecord
             {
                 return new CredentialRecord(
@@ -124,7 +124,7 @@ class PasskeyTest extends TestCase
     public function test_user_can_get_email_based_login_options()
     {
         $user = $this->createUser();
-        $passkey = $this->createPasskey($user);
+        $this->createPasskey($user);
 
         $response = $this->postJson('/api/passkeys/login/options', [
             'email' => $user->email,
@@ -168,14 +168,17 @@ class PasskeyTest extends TestCase
             {
             }
 
-            public function verifyPasskey(array $passkey, string $options, string $host): Passkey
+            public function verifyPasskey(array $passkey, string $options, string $host, ?string $userHandle = null): Passkey
             {
                 return $this->passkey;
             }
         });
 
         $sessionId = 'log_' . uniqid();
-        Cache::put($sessionId, json_encode(['challenge' => 'test']), now()->addMinutes(5));
+        Cache::put($sessionId, json_encode([
+            'options' => json_encode(['challenge' => 'test']),
+            'userHandle' => (string) $user->id,
+        ]), now()->addMinutes(5));
 
         $response = $this->postJson('/api/passkeys/login', [
             'session_id' => $sessionId,
@@ -218,7 +221,9 @@ class PasskeyTest extends TestCase
         ]);
 
         $response->assertStatus(200)
-            ->assertJsonCount(1, 'data.passkeys');
+            ->assertJsonCount(1, 'data.passkeys')
+            ->assertJsonPath('data.passkeys.0.data', null)
+            ->assertJsonPath('data.passkeys.0.keyable_type', null);
     }
 
     public function test_authenticated_user_can_delete_passkey()
@@ -250,7 +255,7 @@ class PasskeyTest extends TestCase
     private function createPasskey($user): Passkey
     {
         $record = new CredentialRecord(
-            publicKeyCredentialId: 'test-id',
+            publicKeyCredentialId: 'test-id-' . uniqid(),
             type: 'public-key',
             transports: ['internal'],
             attestationType: 'none',
@@ -265,7 +270,7 @@ class PasskeyTest extends TestCase
 
         return $user->passkeys()->create([
             'name' => 'Test Passkey',
-            'credential_id' => 'dGVzdA',
+            'credential_id' => 'dGVzdA-' . uniqid(),
             'data' => $data,
         ]);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ namespace Whilesmart\UserAuthentication\Tests;
 use Faker\Factory;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\SanctumServiceProvider;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\SocialiteServiceProvider;
 use Orchestra\Testbench\Attributes\WithMigration;
@@ -47,8 +48,20 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
     {
         return [
             \Whilesmart\UserAuthentication\UserAuthenticationServiceProvider::class,
+            SanctumServiceProvider::class,
             SocialiteServiceProvider::class,
         ];
+    }
+
+    /**
+     * Define environment setup.
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('auth.guards.sanctum', [
+            'driver' => 'sanctum',
+            'provider' => 'users',
+        ]);
     }
 
     /**

--- a/tests/Unit/PasskeyServiceTest.php
+++ b/tests/Unit/PasskeyServiceTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Whilesmart\UserAuthentication\Tests\Unit;
+
+use Symfony\Component\Uid\Uuid;
+use Webauthn\CredentialRecord;
+use Webauthn\TrustPath\EmptyTrustPath;
+use Whilesmart\UserAuthentication\Models\Passkey;
+use Whilesmart\UserAuthentication\Models\User;
+use Whilesmart\UserAuthentication\Services\PasskeyService;
+use Whilesmart\UserAuthentication\Tests\TestCase;
+
+class PasskeyServiceTest extends TestCase
+{
+    public function test_get_registration_options_includes_resident_key_when_enabled()
+    {
+        config()->set('user-authentication.passkey.domain', 'https://app.example.com');
+        config()->set('user-authentication.passkey.resident_keys', true);
+
+        $service = new PasskeyService();
+        $options = $service->getRegistrationOptions('1', 'user@example.com', 'User');
+
+        $this->assertSame('app.example.com', $options->rp->id);
+        $this->assertSame('required', $options->authenticatorSelection->residentKey);
+    }
+
+    public function test_get_registration_options_uses_no_preference_when_resident_keys_disabled()
+    {
+        config()->set('user-authentication.passkey.domain', 'https://app.example.com');
+        config()->set('user-authentication.passkey.resident_keys', false);
+
+        $service = new PasskeyService();
+        $options = $service->getRegistrationOptions('1', 'user@example.com', 'User');
+
+        $this->assertNull($options->authenticatorSelection->residentKey);
+    }
+
+    public function test_get_rp_id_handles_bare_hostname()
+    {
+        config()->set('user-authentication.passkey.domain', 'app.example.com');
+
+        $service = new PasskeyService();
+        $options = $service->getRegistrationOptions('1', 'user@example.com', 'User');
+
+        $this->assertSame('app.example.com', $options->rp->id);
+    }
+
+    public function test_get_login_options_with_user_returns_credentials()
+    {
+        $user = $this->createUser();
+        $this->createPasskey($user);
+
+        config()->set('user-authentication.passkey.domain', 'https://app.example.com');
+
+        $service = new PasskeyService();
+        $options = $service->getLoginOptions($user->id);
+
+        $this->assertSame('app.example.com', $options->rpId);
+        $this->assertCount(1, $options->allowCredentials);
+    }
+
+    public function test_get_login_options_without_user_returns_empty_allow_credentials()
+    {
+        config()->set('user-authentication.passkey.domain', 'https://app.example.com');
+
+        $service = new PasskeyService();
+        $options = $service->getLoginOptions();
+
+        $this->assertSame([], $options->allowCredentials);
+    }
+
+    public function test_get_credential_id_returns_base64url_encoded_id()
+    {
+        $service = new PasskeyService();
+        $record = new CredentialRecord(
+            publicKeyCredentialId: 'test-id',
+            type: 'public-key',
+            transports: [],
+            attestationType: 'none',
+            trustPath: new EmptyTrustPath(),
+            aaguid: Uuid::fromString('00000000-0000-0000-0000-000000000000'),
+            credentialPublicKey: 'key',
+            userHandle: '1',
+            counter: 0,
+        );
+
+        $this->assertSame('dGVzdC1pZA', $service->getCredentialId($record));
+    }
+
+    private function createPasskey(User $user): Passkey
+    {
+        $record = new CredentialRecord(
+            publicKeyCredentialId: 'test-id',
+            type: 'public-key',
+            transports: ['internal'],
+            attestationType: 'none',
+            trustPath: new EmptyTrustPath(),
+            aaguid: Uuid::fromString('00000000-0000-0000-0000-000000000000'),
+            credentialPublicKey: 'key',
+            userHandle: (string) $user->id,
+            counter: 0,
+        );
+
+        $data = Passkey::webAuthnSerializer()->serialize($record, 'json');
+
+        return $user->passkeys()->create([
+            'name' => 'Test Passkey',
+            'credential_id' => 'dGVzdA',
+            'data' => $data,
+        ]);
+    }
+}

--- a/tests/Unit/PasskeyServiceTest.php
+++ b/tests/Unit/PasskeyServiceTest.php
@@ -105,7 +105,7 @@ class PasskeyServiceTest extends TestCase
 
         return $user->passkeys()->create([
             'name' => 'Test Passkey',
-            'credential_id' => 'dGVzdA',
+            'credential_id' => 'dGVzdA-' . uniqid(),
             'data' => $data,
         ]);
     }

--- a/workbench/app/Models/User.php
+++ b/workbench/app/Models/User.php
@@ -2,49 +2,8 @@
 
 namespace Workbench\App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Foundation\Auth\User as Authenticatable;
-use Illuminate\Notifications\Notifiable;
+use Whilesmart\UserAuthentication\Models\User as BaseUser;
 
-class User extends Authenticatable
+class User extends BaseUser
 {
-    /** @use HasFactory<\Workbench\Database\Factories\UserFactory> */
-    use HasFactory;
-
-    use Notifiable;
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var list<string>
-     */
-    protected $fillable = [
-        'name',
-        'email',
-        'password',
-    ];
-
-    /**
-     * The attributes that should be hidden for serialization.
-     *
-     * @var list<string>
-     */
-    protected $hidden = [
-        'password',
-        'remember_token',
-    ];
-
-    /**
-     * Get the attributes that should be cast.
-     *
-     * @return array<string, string>
-     */
-    protected function casts(): array
-    {
-        return [
-            'email_verified_at' => 'datetime',
-            'password' => 'hashed',
-        ];
-    }
 }


### PR DESCRIPTION
## Summary

This PR adds WebAuthn passkey support to the package, including passwordless login, email-based passkey login, and configurable discoverable (resident) credentials.

## What's changed

- **Passkey registration & login endpoints**
  - `POST /passkeys/register/options` and `POST /passkeys/register` for authenticated users
  - `POST /passkeys/login/options` and `POST /passkeys/login` for public access
  - `GET /passkeys` and `DELETE /passkeys/{id}` for managing credentials

- **Passwordless login**
  - Calling `/passkeys/login/options` without an email returns an empty `allowCredentials` list, letting the browser show the passkey picker

- **Documentation**
  - Added `docs/passkey.md` with setup, flows, origin/RP ID guidance, and troubleshooting
  - Updated `README.md` with passkey endpoints, env vars, and links
  - Added `AGENTS.md` for future Agentic sessions

## Checklist

- [x] Add passkey feature
- [x] Add tests
- [x] Add documentation
- [x] Fix PHPStan errors
- [x] Run lint pipeline (`pint`, `phpcs`, `phpstan`)
